### PR TITLE
Always run commands on localhost without sudo

### DIFF
--- a/roles/ad_group_conflicts/tasks/generate_reports.yml
+++ b/roles/ad_group_conflicts/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ ad_group_conflicts_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/ad_user_conflicts/tasks/generate_reports.yml
+++ b/roles/ad_user_conflicts/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ ad_user_conflicts_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_agent_status/tasks/generate_reports.yml
+++ b/roles/client_agent_status/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_agent_status_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_config/tasks/generate_reports.yml
+++ b/roles/client_config/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_config_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_join/tasks/generate_reports.yml
+++ b/roles/client_join/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_join_reports_host }}"    
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_join_status/tasks/generate_reports.yml
+++ b/roles/client_join_status/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_join_status_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_preflight/tasks/generate_reports.yml
+++ b/roles/client_preflight/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_preflight_reports_host }}"    
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/client_preflight/tasks/utils/check_package_directory.yml
+++ b/roles/client_preflight/tasks/utils/check_package_directory.yml
@@ -11,6 +11,8 @@
   delegate_to: "{{ client_sw_host }}"
   failed_when: false
   register: client_sw_pkgs 
+  vars:
+    ansible_become: false
 
 # Fail if there was a message returned
 - fail:

--- a/roles/client_sw/tasks/check_package_directory.yml
+++ b/roles/client_sw/tasks/check_package_directory.yml
@@ -12,6 +12,8 @@
   delegate_to: "{{ client_sw_host }}"
   failed_when: false
   register: client_sw_pkgs 
+  vars:
+    ansible_become: false
 
 # Fail if there was a message returned
 - fail:

--- a/roles/client_sw/tasks/generate_reports.yml
+++ b/roles/client_sw/tasks/generate_reports.yml
@@ -10,3 +10,5 @@
   delegate_to: "{{ client_sw_reports_host }}"    
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/host_access_control/tasks/generate_reports.yml
+++ b/roles/host_access_control/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ host_access_control_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/local_unix_groups/tasks/generate_reports.yml
+++ b/roles/local_unix_groups/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ local_unix_groups_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/local_unix_user_conflicts/tasks/generate_reports.yml
+++ b/roles/local_unix_user_conflicts/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ local_unix_user_conflicts_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/local_unix_users/tasks/generate_reports.yml
+++ b/roles/local_unix_users/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ local_unix_users_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/local_unix_users_with_ad_logon/tasks/generate_reports.yml
+++ b/roles/local_unix_users_with_ad_logon/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ local_unix_users_with_ad_logon_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/logon_policy_for_ad_user/tasks/generate_reports.yml
+++ b/roles/logon_policy_for_ad_user/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ logon_policy_for_ad_user_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/logon_policy_for_unix_host/tasks/generate_reports.yml
+++ b/roles/logon_policy_for_unix_host/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ logon_policy_for_unix_host_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/unix_computers_in_ad/tasks/generate_reports.yml
+++ b/roles/unix_computers_in_ad/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ unix_computers_in_ad_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/unix_enabled_ad_groups/tasks/generate_reports.yml
+++ b/roles/unix_enabled_ad_groups/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ unix_enabled_ad_groups_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false

--- a/roles/unix_enabled_ad_users/tasks/generate_reports.yml
+++ b/roles/unix_enabled_ad_users/tasks/generate_reports.yml
@@ -9,3 +9,5 @@
   delegate_to: "{{ unix_enabled_ad_users_reports_host }}"
   run_once: true
   changed_when: false
+  vars:
+    ansible_become: false


### PR DESCRIPTION
Issue #40 revealed that 'ansible_become: true' affects not only commands run on the managed nodes but also commands run on the control node... That is why we explicitly have to set 'ansible_become: false' for every commands run locally, that is, on the control node.

See github.com/OneIdentity/ansible-authentication-services/issues/40