### PR TITLE
Solaris: install natively so SMF services get registered

### DIFF
--- a/plugins/modules/client_sw_pkgs.py
+++ b/plugins/modules/client_sw_pkgs.py
@@ -431,9 +431,10 @@ def _p5p_packages(archive_path):
     assuming package membership or version from the archive file name.
 
     Returns a tuple (err, packages). 'err' is a message (including the archive
-    path) when the archive cannot be opened or read, so discovery can fail
-    loudly instead of silently returning an empty set and skipping packages the
-    archive was expected to provide.
+    path) when the archive cannot be opened or read, OR when it is readable but
+    contains no recognized package manifests (a corrupt or incomplete .p5p), so
+    discovery can fail loudly instead of silently returning an empty set and
+    skipping packages the archive was expected to provide.
     """
 
     packages = {}
@@ -456,6 +457,15 @@ def _p5p_packages(archive_path):
     finally:
         if tar is not None:
             tar.close()
+
+    # A readable archive that yields no package manifests is corrupt or
+    # incomplete media. Report it rather than let it contribute nothing while
+    # other archives make aggregate discovery look successful - that would let a
+    # requested package be silently skipped.
+    if not packages:
+        return ('Solaris IPS package archive ' + archive_path
+                + ' contains no package manifests (corrupt or incomplete '
+                'media)'), {}
 
     return None, packages
 

--- a/plugins/modules/client_sw_pkgs.py
+++ b/plugins/modules/client_sw_pkgs.py
@@ -47,6 +47,14 @@ options:
         description:
             - Architecture (x86, amd64, etc.)
         required: true
+    ver:
+        description:
+            - OS distribution major version (for example '10' or '11'). Used on
+              Solaris to select SVR4 (Solaris 10) versus native IPS (Solaris 11)
+              package media.
+        type: str
+        required: false
+        default: ''
     path:
         description:
             - Client software directory
@@ -124,6 +132,12 @@ import os
 import traceback
 import glob
 import re
+import tarfile
+
+try:
+    from urllib.parse import unquote
+except ImportError:  # Python 2
+    from urllib import unquote
 
 
 # ------------------------------------------------------------------------------
@@ -210,6 +224,11 @@ def run_module():
                 'type': 'str',
                 'required': True
             },
+            'ver': {
+                'type': 'str',
+                'required': False,
+                'default': ''
+            },
             'path': {
                 'type': 'str',
                 'required': True
@@ -271,6 +290,7 @@ def run_normal(params, result):
     sys = params['sys'].lower()
     dist = params['dist'].lower()
     arch = params['arch'].lower()
+    ver = params.get('ver', '') or ''
     facts = params['facts']
     facts_key = params['facts_key'] if params['facts_key'] else FACTS_KEY_DEFAULT
 
@@ -281,7 +301,7 @@ def run_normal(params, result):
 
         # Find packages
         if err is None:
-            err, packages = find_packages(path, sys, dist, arch)
+            err, packages = find_packages(path, sys, dist, arch, ver)
 
     except Exception:
         tb = traceback.format_exc()
@@ -329,7 +349,7 @@ def check_dir(path):
 
 
 # ------------------------------------------------------------------------------
-def find_packages(sw_path, sys, dist, arch):
+def find_packages(sw_path, sys, dist, arch, ver=''):
     """
     Find packages
     """
@@ -337,6 +357,13 @@ def find_packages(sw_path, sys, dist, arch):
     # Return values
     err = None
     packages = {}
+
+    # Solaris 11 and later ship Authentication Services as a native IPS package
+    # archive (sas-*.p5p) rather than SVR4 datastream packages (*.pkg). Discover
+    # the archive and report the component packages it provides so the install
+    # path can use 'pkg install -g <archive>'.
+    if sys == 'sunos' and _solaris_major(ver) >= 11:
+        return find_packages_solaris_ips(sw_path, arch)
 
     # Find package path for specified sys and arch
     err, pkgs_dir = find_packages_path(sys, arch)
@@ -364,6 +391,108 @@ def find_packages(sw_path, sys, dist, arch):
         err = 'No packages found at ' + sw_path + ' for sys=' + sys + ', dist=' + dist + ', arch=' + arch
 
     # Return
+    return err, packages
+
+
+# ------------------------------------------------------------------------------
+def _solaris_major(ver):
+    """
+    Parse a Solaris major version ('10', '11', '11.4', ...) into an int, 0 if
+    unknown.
+    """
+    try:
+        return int(str(ver).split('.')[0])
+    except (ValueError, TypeError, AttributeError):
+        return 0
+
+
+# ------------------------------------------------------------------------------
+def _version_key(vers):
+    """
+    Turn a dotted version string into a comparable tuple for sorting.
+    """
+    parts = []
+    for part in str(vers).split('.'):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            parts.append(0)
+    return tuple(parts)
+
+
+# ------------------------------------------------------------------------------
+def _p5p_packages(archive_path):
+    """
+    Read the packages (and their real versions) contained in a Solaris IPS
+    package archive (.p5p). A .p5p is a USTAR tar whose package manifests live
+    at 'publisher/<publisher>/pkg/<name>/<encoded-fmri-version>'. The encoded
+    version is URL-quoted and carries the build branch after a comma, for
+    example '1.4.0.70%2C5.11-0%3A...' -> release '1.4.0.70'. This avoids
+    assuming package membership or version from the archive file name.
+    """
+
+    packages = {}
+    tar = None
+    try:
+        tar = tarfile.open(archive_path)
+        for name in tar.getnames():
+            parts = name.split('/')
+            # publisher/<pub>/pkg/<name>/<encoded-version>
+            if (len(parts) == 5 and parts[0] == 'publisher'
+                    and parts[2] == 'pkg' and parts[4]):
+                pkg_name = parts[3]
+                vers = unquote(parts[4]).split(',')[0]
+                if (pkg_name not in packages
+                        or _version_key(vers) > _version_key(packages[pkg_name])):
+                    packages[pkg_name] = vers
+    except (tarfile.TarError, OSError, IOError):
+        packages = {}
+    finally:
+        if tar is not None:
+            tar.close()
+
+    return packages
+
+
+# ------------------------------------------------------------------------------
+def find_packages_solaris_ips(sw_path, arch):
+    """
+    Discover Authentication Services IPS package archives (*.p5p) for Solaris 11
+    and report the component packages they actually contain, with each package's
+    real version, by reading the archive contents. When a package appears in
+    more than one archive (or version) the highest version is selected so both
+    discovery and install use the same, deterministic archive.
+    """
+
+    err = None
+    packages = {}
+
+    if arch in ('sparc', 'sparc64', 'sun4v', 'sun4u'):
+        pkgs_dir = 'solaris11-sparc'
+    else:
+        pkgs_dir = 'solaris11-x64'
+
+    base = os.path.join(sw_path, pkgs_dir)
+
+    for archive in sorted(glob.glob(os.path.join(base, '*.p5p'))):
+        fname = os.path.basename(archive)
+        for pkg_name, vers in _p5p_packages(archive).items():
+            existing = packages.get(pkg_name)
+            if existing is None \
+                    or _version_key(vers) > _version_key(existing['vers']):
+                packages[pkg_name] = {
+                        'path': archive,
+                        'file': fname,
+                        'vers': vers
+                    }
+
+    # Find preflight
+    packages['preflight'] = find_preflight(base)
+
+    if not any(key != 'preflight' for key in packages):
+        err = 'No Authentication Services IPS package archive (*.p5p) found ' \
+            'under ' + base
+
     return err, packages
 
 

--- a/plugins/modules/client_sw_pkgs.py
+++ b/plugins/modules/client_sw_pkgs.py
@@ -361,7 +361,7 @@ def find_packages(sw_path, sys, dist, arch, ver=''):
     # Solaris 11 and later ship Authentication Services as a native IPS package
     # archive (sas-*.p5p) rather than SVR4 datastream packages (*.pkg). Discover
     # the archive and report the component packages it provides so the install
-    # path can use 'pkg install -g <archive>'.
+    # path can install the archive directly or configure it as an IPS origin.
     if sys == 'sunos' and _solaris_major(ver) >= 11:
         return find_packages_solaris_ips(sw_path, arch)
 

--- a/plugins/modules/client_sw_pkgs.py
+++ b/plugins/modules/client_sw_pkgs.py
@@ -429,6 +429,11 @@ def _p5p_packages(archive_path):
     version is URL-quoted and carries the build branch after a comma, for
     example '1.4.0.70%2C5.11-0%3A...' -> release '1.4.0.70'. This avoids
     assuming package membership or version from the archive file name.
+
+    Returns a tuple (err, packages). 'err' is a message (including the archive
+    path) when the archive cannot be opened or read, so discovery can fail
+    loudly instead of silently returning an empty set and skipping packages the
+    archive was expected to provide.
     """
 
     packages = {}
@@ -445,13 +450,14 @@ def _p5p_packages(archive_path):
                 if (pkg_name not in packages
                         or _version_key(vers) > _version_key(packages[pkg_name])):
                     packages[pkg_name] = vers
-    except (tarfile.TarError, OSError, IOError):
-        packages = {}
+    except (tarfile.TarError, OSError, IOError) as read_err:
+        return ('Unable to read Solaris IPS package archive '
+                + archive_path + ': ' + str(read_err)), {}
     finally:
         if tar is not None:
             tar.close()
 
-    return packages
+    return None, packages
 
 
 # ------------------------------------------------------------------------------
@@ -476,7 +482,10 @@ def find_packages_solaris_ips(sw_path, arch):
 
     for archive in sorted(glob.glob(os.path.join(base, '*.p5p'))):
         fname = os.path.basename(archive)
-        for pkg_name, vers in _p5p_packages(archive).items():
+        perr, archive_pkgs = _p5p_packages(archive)
+        if perr:
+            return perr, {}
+        for pkg_name, vers in archive_pkgs.items():
             existing = packages.get(pkg_name)
             if existing is None \
                     or _version_key(vers) > _version_key(existing['vers']):

--- a/roles/client_preflight/tasks/utils/check_package_directory.yml
+++ b/roles/client_preflight/tasks/utils/check_package_directory.yml
@@ -6,6 +6,7 @@
     sys: "{{ ansible_facts['system'] }}" 
     dist: "{{ ansible_facts['os_family'] }}" 
     arch: "{{ ansible_facts['architecture'] }}" 
+    ver: "{{ ansible_facts['distribution_major_version'] | default('') }}"
     path: "{{ client_sw_dir }}" 
     facts: false
   delegate_to: "{{ client_sw_host }}"

--- a/roles/client_sw/README.md
+++ b/roles/client_sw/README.md
@@ -121,6 +121,36 @@ Report generation variable defaults for all roles are set by variables in the [`
 
   The `dest` key for each list entry is the report file on the machine specified in `client_sw_reports_host`.  If `client_sw_reports_host` is set to the Ansible control node a relative path can be used and it will be relative to the directory from which the playbook is run.  For other hosts, an absolute path must be used.  In either case the containing directory must exist.
 
+## Solaris install preflight and linked-image media
+
+Solaris install, upgrade and downgrade operations check required media before
+removing the installed package. On Solaris 11, linked-child discovery and any
+required OneIdentity publisher checks also finish before either SVR4 `pkgrm` or
+IPS uninstall. Query failures, SSL client credentials and inherited/system
+publishers (`SYSPUB=true`) reject the linked-image operation without removing the
+working package or changing its publisher. Absent-only removal does not require
+install media or these install-only checks.
+
+Images with actual linked **children** use a temporary publisher origin. For
+each package operation, the required archive is copied to a unique root-owned
+`/var/tmp/ansible-as-ips-*` directory (0755), with a regular archive file (0644).
+A subprocess drops privileges to the Solaris system-repository worker `pkg5srv`
+and reads the archive before any removal, checking access through all ancestors.
+Caller-owned `client_sw_tmp_dir` parents and pre-existing media are not chmodded.
+The archive contains installation media, not credentials, and is intentionally
+readable by local users during the operation.
+
+The existing publisher's enabled state, origins, origin enable states and proxies
+are restored after the install attempt. Only the operation's own staging directory
+is cleaned, after the temporary origin is detached. If publisher cleanup fails
+and the archive may still be in use, the role reports and retains that directory;
+restore the publisher before removing the reported path. Images without linked
+children retain `pkg install -g`; Solaris 10 retains interactive SVR4 installation.
+
+Check mode performs read-only discovery/publisher checks and checks the controller
+media source, but creates no staging directory and mutates no package or publisher.
+Worker access to a newly staged archive can only be verified during a real run.
+
 ## Plugins
 
 The `client_sw` role contains a few plugins to support operation of the role:

--- a/roles/client_sw/README.md
+++ b/roles/client_sw/README.md
@@ -123,19 +123,28 @@ Report generation variable defaults for all roles are set by variables in the [`
 
 ## Solaris install preflight and linked-image media
 
-Solaris install, upgrade and downgrade operations check required media before
-removing the installed package. On Solaris 11, linked-child discovery and any
-required OneIdentity publisher checks also finish before either SVR4 `pkgrm` or
-IPS uninstall. Query failures, SSL client credentials and inherited/system
-publishers (`SYSPUB=true`) reject the linked-image operation without removing the
-working package or changing its publisher. Absent-only removal does not require
-install media or these install-only checks.
+On Solaris 11, existing IPS packages upgrade or downgrade in place with one
+version-qualified `pkg install` transaction, without a preliminary `pkg uninstall`.
+IPS resolves the requested release and its dependencies together rather than the
+role removing the installed package before an install that might fail. A genuine
+legacy SVR4 package is still removed exactly once with `pkgrm`, after live IPS/SVR4
+registration probes authorise migration. Solaris 10 version transitions retain
+SVR4 removal followed by installation.
+
+Solaris install, upgrade and downgrade operations check required media before any
+package mutation. On Solaris 11, linked-child discovery and any required
+OneIdentity publisher checks also finish before installation or migration
+`pkgrm`. Query failures, SSL client credentials and inherited/system publishers
+(`SYSPUB=true`) reject the linked-image operation without removing the working
+package or changing its publisher. Absent-only removal does not require install
+media or these install-only checks.
 
 Images with actual linked **children** use a temporary publisher origin. For
 each package operation, the required archive is copied to a unique root-owned
 `/var/tmp/ansible-as-ips-*` directory (0755), with a regular archive file (0644).
 A subprocess drops privileges to the Solaris system-repository worker `pkg5srv`
-and reads the archive before any removal, checking access through all ancestors.
+and reads the archive before any package or publisher mutation, checking access
+through all ancestors.
 Caller-owned `client_sw_tmp_dir` parents and pre-existing media are not chmodded.
 The archive contains installation media, not credentials, and is intentionally
 readable by local users during the operation.
@@ -145,7 +154,10 @@ are restored after the install attempt. Only the operation's own staging directo
 is cleaned, after the temporary origin is detached. If publisher cleanup fails
 and the archive may still be in use, the role reports and retains that directory;
 restore the publisher before removing the reported path. Images without linked
-children retain `pkg install -g`; Solaris 10 retains interactive SVR4 installation.
+children retain `pkg install -g`. Both IPS paths use
+`pkg://OneIdentity/<package>@<media-release>` so newer releases in configured
+catalogs cannot override the requested media release; `-g` alone only adds a
+source. Solaris 10 retains interactive SVR4 installation.
 
 Check mode performs read-only discovery/publisher checks and checks the controller
 media source, but creates no staging directory and mutates no package or publisher.

--- a/roles/client_sw/tasks/check_package_directory.yml
+++ b/roles/client_sw/tasks/check_package_directory.yml
@@ -6,6 +6,7 @@
     sys: "{{ ansible_facts['system'] }}" 
     dist: "{{ ansible_facts['os_family'] }}" 
     arch: "{{ ansible_facts['architecture'] }}" 
+    ver: "{{ ansible_facts['distribution_major_version'] | default('') }}"
     path: "{{ client_sw_dir }}" 
     facts: true
     facts_key: 'sas_client_sw_pkgs'

--- a/roles/client_sw/tasks/main.yml
+++ b/roles/client_sw/tasks/main.yml
@@ -20,8 +20,8 @@
 #       - macos-1012 (*.dmg)            # Multiple install packages in single dmg
 #       - solaris10-sparc (*.pkg)         # SVR4, interactive pkgadd
 #       - solaris10-x64 (*.pkg)           # SVR4, interactive pkgadd
-#       - solaris11-sparc (sas-*.p5p)     # IPS, pkg install -g
-#       - solaris11-x64 (sas-*.p5p)       # IPS, pkg install -g
+#       - solaris11-sparc (sas-*.p5p)     # IPS archive
+#       - solaris11-x64 (sas-*.p5p)       # IPS archive
 
 # NOTE: Ansible has following package managers implemented: 
 #       - Linux (*.deb) = apt 

--- a/roles/client_sw/tasks/main.yml
+++ b/roles/client_sw/tasks/main.yml
@@ -18,8 +18,10 @@
 #       - linux-x86 (*.rpm, *.deb)
 #       - linux-x86_64 (*.rpm, *.deb)
 #       - macos-1012 (*.dmg)            # Multiple install packages in single dmg
-#       - solaris10-sparc (*.pkg)
-#       - solaris10-x64 (*.pkg)
+#       - solaris10-sparc (*.pkg)         # SVR4, interactive pkgadd
+#       - solaris10-x64 (*.pkg)           # SVR4, interactive pkgadd
+#       - solaris11-sparc (sas-*.p5p)     # IPS, pkg install -g
+#       - solaris11-x64 (sas-*.p5p)       # IPS, pkg install -g
 
 # NOTE: Ansible has following package managers implemented: 
 #       - Linux (*.deb) = apt 

--- a/roles/client_sw/tasks/os/solaris/downgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/downgrade.yml
@@ -3,7 +3,7 @@
 # ------------------------------------------------------------------------------
 # Solaris - downgrade package
 #
-# Neither SVR4 nor 'pkg install -g' downgrades a package in place, so remove the
+# Neither SVR4 nor the native IPS install downgrades a package in place, so remove the
 # currently installed package(s) then install the target version. remove.yml
 # cleans whichever database holds the package (IPS and/or SVR4). install.yml
 # then installs the target; its SVR4 -> IPS migration step probes the live SVR4

--- a/roles/client_sw/tasks/os/solaris/downgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/downgrade.yml
@@ -4,8 +4,12 @@
 # Solaris - downgrade package
 #
 # Neither SVR4 nor 'pkg install -g' downgrades a package in place, so remove the
-# installed package then install the target version. On Solaris 11 remove.yml
-# uses 'pkg uninstall' and install.yml uses 'pkg install -g'.
+# currently installed package(s) then install the target version. remove.yml
+# cleans whichever database holds the package (IPS and/or SVR4). install.yml
+# then installs the target; its SVR4 -> IPS migration step probes the live SVR4
+# state, so it is a safe no-op here even though remove.yml has already cleared
+# any SVR4 registration - this avoids a double pkgrm when a legacy SVR4 package
+# on Solaris 11 is downgraded to older IPS media.
 # ------------------------------------------------------------------------------
 
 - include_tasks: "remove.yml"

--- a/roles/client_sw/tasks/os/solaris/downgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/downgrade.yml
@@ -2,6 +2,10 @@
 
 # ------------------------------------------------------------------------------
 # Solaris - downgrade package
+#
+# Neither SVR4 nor 'pkg install -g' downgrades a package in place, so remove the
+# installed package then install the target version. On Solaris 11 remove.yml
+# uses 'pkg uninstall' and install.yml uses 'pkg install -g'.
 # ------------------------------------------------------------------------------
 
 - include_tasks: "remove.yml"

--- a/roles/client_sw/tasks/os/solaris/downgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/downgrade.yml
@@ -3,17 +3,19 @@
 # ------------------------------------------------------------------------------
 # Solaris - downgrade package
 #
-# Neither SVR4 nor the native IPS install downgrades a package in place, so remove the
-# currently installed package(s) then install the target version. install.yml
-# first preflights eligibility AND required media before invoking remove.yml.
-# It owns any staged archive through publisher restoration and cleanup.
-# remove.yml cleans whichever database holds the package (IPS or SVR4). install.yml
-# then installs the target; its SVR4 -> IPS migration step probes the live SVR4
-# state, so it is a safe no-op here even though remove.yml has already cleared
-# any SVR4 registration - this avoids a double pkgrm when a legacy SVR4 package
-# on Solaris 11 is downgraded to older IPS media.
+#   * Solaris 11+ : IPS can install an older, version-qualified FMRI in place.
+#                   Do not uninstall first: let IPS resolve the version and its
+#                   dependencies in one transaction, preserving the installed
+#                   package if the install cannot proceed. A genuine legacy
+#                   SVR4 package is removed exactly once by install_package.yml's
+#                   live-probe migration, after install.yml preflights media.
+#   * Solaris 10  : retain the SVR4 remove-then-install transition, with required
+#                   media checked before remove.yml runs.
+#
+# install.yml owns preflight and any stage through publisher restoration/cleanup.
 # ------------------------------------------------------------------------------
 
 - include_tasks: "install.yml"
   vars:
-    sas_solaris_remove_before_install: true
+    sas_solaris_remove_before_install: >-
+      {{ ansible_facts['distribution_major_version'] is version('11', '<') }}

--- a/roles/client_sw/tasks/os/solaris/downgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/downgrade.yml
@@ -4,13 +4,16 @@
 # Solaris - downgrade package
 #
 # Neither SVR4 nor the native IPS install downgrades a package in place, so remove the
-# currently installed package(s) then install the target version. remove.yml
-# cleans whichever database holds the package (IPS and/or SVR4). install.yml
+# currently installed package(s) then install the target version. install.yml
+# first preflights eligibility AND required media before invoking remove.yml.
+# It owns any staged archive through publisher restoration and cleanup.
+# remove.yml cleans whichever database holds the package (IPS or SVR4). install.yml
 # then installs the target; its SVR4 -> IPS migration step probes the live SVR4
 # state, so it is a safe no-op here even though remove.yml has already cleared
 # any SVR4 registration - this avoids a double pkgrm when a legacy SVR4 package
 # on Solaris 11 is downgraded to older IPS media.
 # ------------------------------------------------------------------------------
 
-- include_tasks: "remove.yml"
 - include_tasks: "install.yml"
+  vars:
+    sas_solaris_remove_before_install: true

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -1,483 +1,56 @@
 ---
 
-# ------------------------------------------------------------------------------
-# Solaris - install package
-#
-# Branch on the OS major version:
-#
-#   * Solaris 11+ : install natively from the IPS archive discovered by
-#                   client_sw_pkgs (sas-*.p5p). Images without linked child
-#                   zones use the ephemeral 'pkg install -g' path. Since '-g'
-#                   is prohibited when linked non-global zones exist, those
-#                   images temporarily configure the archive as the sole
-#                   OneIdentity publisher origin, install the exact package
-#                   version, then restore the previous publisher state.
-#                   If the package is currently registered in the SVR4 database
-#                   (a host installed by an older release of this collection),
-#                   the legacy .pkg is removed first so the stale SVR4
-#                   registration and SMF state are cleaned up before the IPS
-#                   package is installed. The native install also upgrades an
-#                   already-IPS package in place, so the upgrade path reuses
-#                   this file.
-#
-#   * Solaris 10  : install the SVR4 package with an interactive pkgadd
-#                   (answering 'y', no '-n') so the SVR4 request script runs and
-#                   the postinstall registers the service. The 'svr4pkg' module
-#                   runs 'pkgadd -n', which skips the request script that sets
-#                   $SERVICES/$CLASSES, leaving the service unregistered.
-# ------------------------------------------------------------------------------
-
-- name: set Authentication Services Solaris packaging facts
+# One operation owns preflight, optional downgrade/SVR4-upgrade removal, native
+# install and archive cleanup. In particular, downgrade must not call remove.yml
+# before checking the linked-image publisher and the REQUIRED install media.
+# Absent-only operations still call remove.yml directly, without media checks.
+- name: reset Solaris install operation state
   set_fact:
     sas_solaris_is_ips: >-
-      {{ ansible_facts['distribution_major_version']
-         is version('11', '>=') }}
+      {{ ansible_facts['distribution_major_version'] is version('11', '>=') }}
+    sas_solaris_has_linked_images: false
+    sas_ips_stage: {}
+    sas_ips_archive_in_use: false
+    # Facts are host-scoped; never reuse a previous package's mutation markers.
+    sas_oneidentity_publisher_line: ""
+    sas_oneidentity_origin_lines: []
+    sas_oneidentity_publisher_exists: false
+    sas_oneidentity_publisher_enabled: true
+    sas_oneidentity_has_ssl_credentials: false
+    sas_oneidentity_origins_replaced: false
+    sas_oneidentity_publisher_temporarily_enabled: false
+    sas_oneidentity_cleanup_errors: []
 
-# Copy the discovered install archive/package to the target. On Solaris 11 this
-# is the shared sas-*.p5p; on Solaris 10 it is the per-package .pkg.
-- include_tasks: package_copy.yml
-
-# On Solaris 11, decide whether a GENUINE legacy SVR4 install must be removed
-# before the IPS install. Probe the LIVE state (rather than a cached fact) so
-# this is idempotent - it is safe to run this file more than once for the same
-# package (for example the downgrade path removes the package first, then
-# installs). A package is a genuine legacy SVR4 install only when 'pkginfo'
-# finds it AND 'pkg info' does not: on Solaris 11 'pkginfo' also lists IPS
-# packages, so probing 'pkginfo' alone would pkgrm the live IPS package on an
-# ordinary reinstall/upgrade.
-- name: "check {{ package }} IPS registration"
-  command:
-    cmd: "pkg info '{{ package }}'"
-  register: sas_ips_present
-  changed_when: false
-  failed_when: false
-  check_mode: false
-  environment:
-    LC_ALL: C
-  when: sas_solaris_is_ips | bool
-
-- name: "check {{ package }} SVR4 registration"
-  command:
-    cmd: "pkginfo '{{ package }}'"
-  register: sas_svr4_present
-  changed_when: false
-  failed_when: false
-  check_mode: false
-  environment:
-    LC_ALL: C
-  when: sas_solaris_is_ips | bool
-
-# Fail closed on an inconclusive probe: only the recognised not-installed
-# message may authorise treating a database as empty. An operational error must
-# not be read as "IPS absent" and let the migration pkgrm below remove a live
-# IPS package.
-- name: "verify {{ package }} IPS probe is conclusive"
-  fail:
-    msg: >-
-      Could not determine the IPS registration of {{ package }}: 'pkg info'
-      exited {{ sas_ips_present.rc }} with unexpected output -
-      {{ (sas_ips_present.stderr | default('') | trim)
-         or (sas_ips_present.stdout | default('') | trim) }}
-  when:
-    - sas_solaris_is_ips | bool
-    - (sas_ips_present.rc | default(1)) != 0
-    - not (sas_ips_present.stderr | default('') is search('no packages matching'))
-
-- name: "verify {{ package }} SVR4 probe is conclusive"
-  fail:
-    msg: >-
-      Could not determine the SVR4 registration of {{ package }}: 'pkginfo'
-      exited {{ sas_svr4_present.rc }} with unexpected output -
-      {{ (sas_svr4_present.stderr | default('') | trim)
-         or (sas_svr4_present.stdout | default('') | trim) }}
-  when:
-    - sas_solaris_is_ips | bool
-    - (sas_svr4_present.rc | default(1)) != 0
-    - not (sas_svr4_present.stderr | default('') is search('was not found'))
-
-- name: "flag {{ package }} as a genuine legacy SVR4 install"
-  set_fact:
-    sas_migrate_svr4: >-
-      {{ (sas_svr4_present.rc | default(1)) == 0
-         and (sas_ips_present.rc | default(1)) != 0 }}
-  when: sas_solaris_is_ips | bool
-
-# The admin file lets pkgadd/pkgrm run non-interactively while still executing
-# the SVR4 request script (unlike 'pkgadd -n'/'pkgrm -n'). It is needed for the
-# Solaris 10 pkgadd and for the Solaris 11 SVR4 -> IPS migration pkgrm.
-- name: create SVR4 admin file
-  copy:
-    dest: "{{ package_dest_dir }}vas.admin"
-    mode: "0644"
-    content: |
-      mail=
-      instance=overwrite
-      partial=nocheck
-      runlevel=nocheck
-      idepend=nocheck
-      rdepend=nocheck
-      space=nocheck
-      setuid=nocheck
-      conflict=nocheck
-      action=nocheck
-      basedir=default
-  changed_when: false
-  when: >-
-    not (sas_solaris_is_ips | bool)
-    or (sas_migrate_svr4 | default(false) | bool)
-
-# ------------------------------------------------------------------------------
-# Solaris 11+ : native IPS install (with legacy SVR4 -> IPS migration)
-# ------------------------------------------------------------------------------
-- name: "migrate legacy SVR4 {{ package }} to IPS"
-  shell:
-    cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
-  register: sas_svr4_migrate
-  # pkgrm(1M) documents 2 (warning) and 10/20 (reboot required) as completed
-  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
-  # so a completed removal is not sent to 'rescue'.
-  changed_when: sas_svr4_migrate.rc in [0, 2, 10, 20]
-  failed_when: sas_svr4_migrate.rc not in [0, 2, 10, 20]
-  when:
-    - sas_solaris_is_ips | bool
-    - sas_migrate_svr4 | default(false) | bool
-
-- name: "note {{ package }} SVR4 removal reboot/warning status"
-  debug:
-    msg: >-
-      pkgrm for {{ package }} completed with return code
-      {{ sas_svr4_migrate.rc }}
-      ({{ 'reboot required' if sas_svr4_migrate.rc in [10, 20] else 'warning' }}).
-  when:
-    - sas_solaris_is_ips | bool
-    - sas_migrate_svr4 | default(false) | bool
-    - sas_svr4_migrate.rc | default(0) in [2, 10, 20]
-
-# A per-operation '-g <archive>' origin is prohibited when the image has linked
-# children (non-global zones). Use it for ordinary images and reserve the more
-# invasive publisher transaction below for images that actually need it.
-- name: check for linked IPS child images
-  command:
-    cmd: "pkg list-linked -H"
-  register: sas_ips_linked_images
-  changed_when: false
-  check_mode: false
-  environment:
-    LC_ALL: C
-  when: sas_solaris_is_ips | bool
-
-- name: record linked IPS child image state
-  set_fact:
-    sas_solaris_has_linked_images: >-
-      {{ (sas_ips_linked_images.stdout | default('')
-          | regex_findall('(?m)^\S+\s+child\s+\S+')
-          | length) > 0 }}
-  when: sas_solaris_is_ips | bool
-
-- name: "install {{ package }} directly from IPS archive"
-  command:
-    cmd: "pkg install --accept -g '{{ package_dest }}' '{{ package }}'"
-  register: pkg_install
-  changed_when: pkg_install.rc == 0
-  # pkg rc 4 == "nothing to do" (already at the requested version)
-  failed_when:
-    - pkg_install.rc != 0
-    - pkg_install.rc != 4
-  when:
-    - sas_solaris_is_ips | bool
-    - not (sas_solaris_has_linked_images | bool)
-
-# Linked child images require the archive to be an ordinary publisher origin.
-# Snapshot the existing OneIdentity configuration, replace its origins for the
-# duration of the exact-version install, and attempt every restoration step in
-# an always block. Existing SSL-authenticated origins fail closed before any
-# mutation because removing an origin deletes IPS's private key/certificate
-# copies and the CLI has no lossless publisher export facility.
-- name: "install {{ package }} from IPS publisher for linked images"
+- name: "prepare and install {{ package }} on Solaris"
   block:
 
-    # These are host-scoped facts and install.yml is included once per package.
-    # Reset every per-operation value before any command can fail so the always
-    # cleanup cannot act on values left by a previous package iteration.
-    - name: reset temporary OneIdentity publisher operation state
-      set_fact:
-        sas_oneidentity_publisher_line: ""
-        sas_oneidentity_origin_lines: []
-        sas_oneidentity_publisher_exists: false
-        sas_oneidentity_publisher_enabled: true
-        sas_oneidentity_has_ssl_credentials: false
-        sas_oneidentity_origins_replaced: false
-        sas_oneidentity_publisher_temporarily_enabled: false
-        sas_oneidentity_cleanup_errors: []
+    - include_tasks: install_preflight.yml
 
-    - name: get current IPS publisher configuration
-      command:
-        cmd: "pkg publisher -H -F tsv"
-      register: sas_ips_publishers
-      changed_when: false
-      check_mode: false
-      environment:
-        LC_ALL: C
+    - include_tasks: remove.yml
+      when: sas_solaris_remove_before_install | default(false) | bool
 
-    - name: record existing OneIdentity publisher line
-      set_fact:
-        sas_oneidentity_publisher_line: >-
-          {{ (sas_ips_publishers.stdout_lines | default([])
-              | select('match', '^OneIdentity\t')
-              | list | first | default('', true)) }}
-
-    # The TSV ENABLED column is unreliable for disabled publishers that still
-    # have origins on Solaris 11.4 (it remains "true"). The detail view's
-    # "Publisher enabled: Yes/No" value is authoritative.
-    - name: get current OneIdentity publisher properties
-      command:
-        cmd: "pkg publisher OneIdentity"
-      register: sas_oneidentity_publisher_details
-      changed_when: false
-      failed_when: false
-      check_mode: false
-      environment:
-        LC_ALL: C
-      when: (sas_oneidentity_publisher_line | length) > 0
-
-    # 'pkg publisher' can return 3 for a certificate-expiry warning while still
-    # emitting the complete configuration. Accept that usable output, but fail
-    # closed if the expected identity/enabled fields are missing.
-    - name: verify OneIdentity publisher properties are conclusive
-      fail:
-        msg: >-
-          Could not read the complete OneIdentity publisher configuration:
-          {{ (sas_oneidentity_publisher_details.stderr | default('') | trim)
-             or ('pkg publisher exited '
-                 ~ (sas_oneidentity_publisher_details.rc | string)) }}
-      when:
-        - (sas_oneidentity_publisher_line | length) > 0
-        - >-
-          not (sas_oneidentity_publisher_details.stdout | default('')
-               is search('Publisher:\s+OneIdentity'))
-          or not (sas_oneidentity_publisher_details.stdout | default('')
-                  is search('(?:Publisher enabled|Enabled):\s+(?:Yes|No)'))
-
-    - name: record existing OneIdentity publisher state
-      set_fact:
-        sas_oneidentity_origin_lines: >-
-          {{ sas_ips_publishers.stdout_lines | default([])
-             | select('match', '^OneIdentity\t.*\torigin\t')
-             | list }}
-        sas_oneidentity_publisher_exists: >-
-          {{ (sas_oneidentity_publisher_line | length) > 0 }}
-        sas_oneidentity_publisher_enabled: >-
-          {{ sas_oneidentity_publisher_details.stdout | default('')
-             is search('(?:Publisher enabled|Enabled):\s+Yes') }}
-        sas_oneidentity_has_ssl_credentials: >-
-          {{ sas_oneidentity_publisher_details.stdout | default('')
-             is search('SSL (?:Key|Cert):\s+(?!None(?:\s|$))\S+') }}
-
-    - name: reject unsafe replacement of SSL-authenticated publisher origins
-      fail:
-        msg: >-
-          Cannot install {{ package }} for linked IPS images because the
-          existing OneIdentity publisher uses SSL client credentials. Solaris
-          deletes its private credential copies when origins are removed, so
-          the publisher cannot be restored losslessly. Remove or separately
-          preserve that publisher configuration before running this role.
-      when:
-        - sas_oneidentity_publisher_exists | bool
-        - sas_oneidentity_has_ssl_credentials | bool
-
-    # Origins under one IPS publisher are replicas, not ordered alternatives.
-    # Replace every existing origin so IPS can only fetch the requested build
-    # from package_dest; restore the full original list in the always block.
-    - name: temporarily replace OneIdentity publisher origins
-      command:
-        cmd: >-
-          pkg set-publisher
-          {{ "-G '*' " if sas_oneidentity_publisher_exists | bool else "" }}
-          -g '{{ package_dest }}' OneIdentity
-      register: sas_oneidentity_origins_replace
-      changed_when: false
-
-    - name: record replaced OneIdentity publisher origins
-      set_fact:
-        sas_oneidentity_origins_replaced: true
-      when:
-        - sas_oneidentity_origins_replace is defined
-        - not (sas_oneidentity_origins_replace.skipped | default(false))
-        - (sas_oneidentity_origins_replace.rc | default(1)) == 0
-
-    # Replace origins before enabling a disabled publisher. A publisher is often
-    # disabled because its old origin is unreachable; enabling first could
-    # refresh that bad origin and fail before the supplied archive is configured.
-    - name: temporarily enable the OneIdentity publisher
-      command:
-        cmd: "pkg set-publisher --enable OneIdentity"
-      register: sas_oneidentity_publisher_enable
-      changed_when: false
-      when:
-        - sas_oneidentity_publisher_exists | bool
-        - not (sas_oneidentity_publisher_enabled | bool)
-
-    - name: record temporarily enabled OneIdentity publisher
-      set_fact:
-        sas_oneidentity_publisher_temporarily_enabled: true
-      when:
-        - sas_oneidentity_publisher_enable is defined
-        - not (sas_oneidentity_publisher_enable.skipped | default(false))
-        - (sas_oneidentity_publisher_enable.rc | default(1)) == 0
-
-    - name: "install {{ package }} from configured IPS publisher"
-      command:
-        cmd: >-
-          pkg install --accept
-          'pkg://OneIdentity/{{ package }}@{{ client_sw_pkgs['packages'][package]['vers'] }}'
-      register: pkg_install
-      changed_when: pkg_install.rc == 0
-      # pkg rc 4 == "nothing to do" (already at the requested version)
-      failed_when:
-        - pkg_install.rc != 0
-        - pkg_install.rc != 4
+    # Keep the live pkg info/pkginfo probes in this helper AFTER an optional
+    # removal: cached version facts still describe the old SVR4 install during
+    # downgrade and must not cause a second pkgrm.
+    - include_tasks: install_package.yml
 
   always:
 
-    # Restore an originally disabled publisher before adding its old origins.
-    # This prevents IPS from refreshing intentionally unreachable origins.
-    - name: restore the disabled OneIdentity publisher
-      command:
-        cmd: "pkg set-publisher --disable OneIdentity"
-      register: sas_oneidentity_publisher_disable
-      changed_when: false
-      failed_when: false
-      when:
-        - sas_oneidentity_publisher_exists | default(false) | bool
-        - sas_oneidentity_publisher_temporarily_enabled | default(false) | bool
-
-    - name: record OneIdentity publisher disable failure
-      set_fact:
-        sas_oneidentity_cleanup_errors: >-
-          {{ sas_oneidentity_cleanup_errors
-             + ['could not restore disabled OneIdentity publisher'
-                ~ ' (rc=' ~ (sas_oneidentity_publisher_disable.rc | string) ~ ')'] }}
-      when:
-        - sas_oneidentity_publisher_disable is defined
-        - not (sas_oneidentity_publisher_disable.skipped | default(false))
-        - (sas_oneidentity_publisher_disable.rc | default(0)) != 0
-
-    - name: remove the temporary OneIdentity publisher origins
-      command:
-        cmd: "pkg set-publisher --no-refresh -G '*' OneIdentity"
-      register: sas_oneidentity_origins_remove
-      changed_when: false
-      failed_when: false
-      when:
-        - sas_oneidentity_publisher_exists | default(false) | bool
-        - sas_oneidentity_origins_replaced | default(false) | bool
-
-    - name: record temporary OneIdentity origins cleanup failure
-      set_fact:
-        sas_oneidentity_cleanup_errors: >-
-          {{ sas_oneidentity_cleanup_errors
-             + ['could not remove temporary OneIdentity origins'
-                ~ ' (rc=' ~ (sas_oneidentity_origins_remove.rc | string) ~ ')'] }}
-      when:
-        - sas_oneidentity_origins_remove is defined
-        - not (sas_oneidentity_origins_remove.skipped | default(false))
-        - (sas_oneidentity_origins_remove.rc | default(0)) != 0
-
-    - name: restore OneIdentity publisher origins
-      command:
-        cmd: >-
-          pkg set-publisher --no-refresh
-          {{ "--disable"
-             if sas_oneidentity_origin_fields[3] == 'false'
-             else "" }}
-          -g '{{ sas_oneidentity_origin_fields[6] }}'
-          {{ "--proxy '" ~ sas_oneidentity_origin_fields[7] ~ "'"
-             if (sas_oneidentity_origin_fields | length) > 7
-                and sas_oneidentity_origin_fields[7] not in ['', '-']
-             else "" }}
-          OneIdentity
-      loop: "{{ sas_oneidentity_origin_lines | default([]) }}"
-      loop_control:
-        loop_var: sas_oneidentity_origin_line
-      register: sas_oneidentity_origins_restore
-      changed_when: false
-      failed_when: false
-      when:
-        - sas_oneidentity_publisher_exists | default(false) | bool
-        - sas_oneidentity_origins_replaced | default(false) | bool
-      vars:
-        sas_oneidentity_origin_fields: "{{ sas_oneidentity_origin_line.split('\t') }}"
-
-    - name: record OneIdentity publisher origin restore failures
-      set_fact:
-        sas_oneidentity_cleanup_errors: >-
-          {{ sas_oneidentity_cleanup_errors
-             + ['could not restore OneIdentity origin '
-                ~ sas_oneidentity_origin_result.sas_oneidentity_origin_line.split('\t')[6]
-                ~ ' (rc=' ~ (sas_oneidentity_origin_result.rc | string) ~ ')'] }}
-      loop: "{{ sas_oneidentity_origins_restore.results | default([]) }}"
-      loop_control:
-        loop_var: sas_oneidentity_origin_result
-      when:
-        - not (sas_oneidentity_origin_result.skipped | default(false))
-        - (sas_oneidentity_origin_result.rc | default(0)) != 0
-
-    - name: remove the temporary OneIdentity publisher
-      command:
-        cmd: "pkg unset-publisher OneIdentity"
-      register: sas_oneidentity_publisher_unset
-      changed_when: false
-      failed_when: false
-      when:
-        - not (sas_oneidentity_publisher_exists | default(true) | bool)
-        - sas_oneidentity_origins_replaced | default(false) | bool
-
-    - name: record temporary OneIdentity publisher cleanup failure
-      set_fact:
-        sas_oneidentity_cleanup_errors: >-
-          {{ sas_oneidentity_cleanup_errors
-             + ['could not remove temporary OneIdentity publisher'
-                ~ ' (rc=' ~ (sas_oneidentity_publisher_unset.rc | string) ~ ')'] }}
-      when:
-        - sas_oneidentity_publisher_unset is defined
-        - not (sas_oneidentity_publisher_unset.skipped | default(false))
-        - (sas_oneidentity_publisher_unset.rc | default(0)) != 0
-
-    - name: fail if temporary OneIdentity publisher cleanup was incomplete
-      fail:
+    - name: report staged IPS archive retained for an unrestored publisher
+      debug:
         msg: >-
-          Failed to restore the OneIdentity IPS publisher configuration:
-          {{ sas_oneidentity_cleanup_errors | join('; ') }}
-      when: (sas_oneidentity_cleanup_errors | default([]) | length) > 0
+          Retaining {{ sas_ips_stage.path }} because the temporary OneIdentity
+          origin may still use its archive. Restore the publisher configuration
+          before removing this directory.
+      when:
+        - sas_ips_stage.path is defined
+        - sas_ips_archive_in_use | bool
 
-  when:
-    - sas_solaris_is_ips | bool
-    - sas_solaris_has_linked_images | bool
-
-# ------------------------------------------------------------------------------
-# Solaris 10 : SVR4 install via interactive pkgadd
-# ------------------------------------------------------------------------------
-# NOTE: Do NOT use the 'svr4pkg' module here - it runs 'pkgadd -n' and the SVR4
-# request script (which sets $SERVICES/$CLASSES) is skipped, leaving vasd's SMF
-# service unregistered. 'yes |' answers the request script prompts.
-- name: "install {{ package }}"
-  shell:
-    cmd: >-
-      yes | pkgadd -a '{{ package_dest_dir }}vas.admin'
-      -G -d '{{ package_dest }}' '{{ package }}'
-  register: pkg_install
-  # pkgadd(1M) documents 2 (warning) and 10/20 (reboot required) as completed
-  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
-  # so a completed install is not reported as a failure.
-  changed_when: pkg_install.rc in [0, 2, 10, 20]
-  failed_when: pkg_install.rc not in [0, 2, 10, 20]
-  when: not (sas_solaris_is_ips | bool)
-
-- name: "note {{ package }} pkgadd reboot/warning status"
-  debug:
-    msg: >-
-      pkgadd for {{ package }} completed with return code {{ pkg_install.rc }}
-      ({{ 'reboot required' if pkg_install.rc in [10, 20] else 'warning' }}).
-  when:
-    - not (sas_solaris_is_ips | bool)
-    - pkg_install.rc | default(0) in [2, 10, 20]
+    - name: remove this operation's unused IPS archive directory
+      file:
+        path: "{{ sas_ips_stage.path }}"
+        state: absent
+      changed_when: false
+      when:
+        - sas_ips_stage.path is defined
+        - not (sas_ips_archive_in_use | bool)

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -47,6 +47,8 @@
   register: sas_ips_present
   changed_when: false
   failed_when: false
+  environment:
+    LC_ALL: C
   when: sas_solaris_is_ips | bool
 
 - name: "check {{ package }} SVR4 registration"
@@ -55,7 +57,37 @@
   register: sas_svr4_present
   changed_when: false
   failed_when: false
+  environment:
+    LC_ALL: C
   when: sas_solaris_is_ips | bool
+
+# Fail closed on an inconclusive probe: only the recognised not-installed
+# message may authorise treating a database as empty. An operational error must
+# not be read as "IPS absent" and let the migration pkgrm below remove a live
+# IPS package.
+- name: "verify {{ package }} IPS probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the IPS registration of {{ package }}: 'pkg info'
+      exited {{ sas_ips_present.rc }} with unexpected output -
+      {{ (sas_ips_present.stderr | default('') | trim)
+         or (sas_ips_present.stdout | default('') | trim) }}
+  when:
+    - sas_solaris_is_ips | bool
+    - (sas_ips_present.rc | default(1)) != 0
+    - not (sas_ips_present.stderr | default('') is search('no packages matching'))
+
+- name: "verify {{ package }} SVR4 probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the SVR4 registration of {{ package }}: 'pkginfo'
+      exited {{ sas_svr4_present.rc }} with unexpected output -
+      {{ (sas_svr4_present.stderr | default('') | trim)
+         or (sas_svr4_present.stdout | default('') | trim) }}
+  when:
+    - sas_solaris_is_ips | bool
+    - (sas_svr4_present.rc | default(1)) != 0
+    - not (sas_svr4_present.stderr | default('') is search('was not found'))
 
 - name: "flag {{ package }} as a genuine legacy SVR4 install"
   set_fact:
@@ -95,10 +127,25 @@
   shell:
     cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
   register: sas_svr4_migrate
-  changed_when: true
+  # pkgrm(1M) documents 2 (warning) and 10/20 (reboot required) as completed
+  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
+  # so a completed removal is not sent to 'rescue'.
+  changed_when: sas_svr4_migrate.rc in [0, 2, 10, 20]
+  failed_when: sas_svr4_migrate.rc not in [0, 2, 10, 20]
   when:
     - sas_solaris_is_ips | bool
     - sas_migrate_svr4 | default(false) | bool
+
+- name: "note {{ package }} SVR4 removal reboot/warning status"
+  debug:
+    msg: >-
+      pkgrm for {{ package }} completed with return code
+      {{ sas_svr4_migrate.rc }}
+      ({{ 'reboot required' if sas_svr4_migrate.rc in [10, 20] else 'warning' }}).
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_migrate_svr4 | default(false) | bool
+    - sas_svr4_migrate.rc | default(0) in [2, 10, 20]
 
 - name: "install {{ package }} from IPS archive"
   command:
@@ -123,5 +170,18 @@
       yes | pkgadd -a '{{ package_dest_dir }}vas.admin'
       -G -d '{{ package_dest }}' '{{ package }}'
   register: pkg_install
-  changed_when: pkg_install.rc == 0
+  # pkgadd(1M) documents 2 (warning) and 10/20 (reboot required) as completed
+  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
+  # so a completed install is not reported as a failure.
+  changed_when: pkg_install.rc in [0, 2, 10, 20]
+  failed_when: pkg_install.rc not in [0, 2, 10, 20]
   when: not (sas_solaris_is_ips | bool)
+
+- name: "note {{ package }} pkgadd reboot/warning status"
+  debug:
+    msg: >-
+      pkgadd for {{ package }} completed with return code {{ pkg_install.rc }}
+      ({{ 'reboot required' if pkg_install.rc in [10, 20] else 'warning' }}).
+  when:
+    - not (sas_solaris_is_ips | bool)
+    - pkg_install.rc | default(0) in [2, 10, 20]

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -28,16 +28,45 @@
     sas_solaris_is_ips: >-
       {{ ansible_facts['distribution_major_version']
          is version('11', '>=') }}
-    sas_pkgsys: >-
-      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_pkgsys']
-         | default('') }}
 
 # Copy the discovered install archive/package to the target. On Solaris 11 this
 # is the shared sas-*.p5p; on Solaris 10 it is the per-package .pkg.
 - include_tasks: package_copy.yml
 
+# On Solaris 11, decide whether a GENUINE legacy SVR4 install must be removed
+# before the IPS install. Probe the LIVE state (rather than a cached fact) so
+# this is idempotent - it is safe to run this file more than once for the same
+# package (for example the downgrade path removes the package first, then
+# installs). A package is a genuine legacy SVR4 install only when 'pkginfo'
+# finds it AND 'pkg info' does not: on Solaris 11 'pkginfo' also lists IPS
+# packages, so probing 'pkginfo' alone would pkgrm the live IPS package on an
+# ordinary reinstall/upgrade.
+- name: "check {{ package }} IPS registration"
+  command:
+    cmd: "pkg info '{{ package }}'"
+  register: sas_ips_present
+  changed_when: false
+  failed_when: false
+  when: sas_solaris_is_ips | bool
+
+- name: "check {{ package }} SVR4 registration"
+  command:
+    cmd: "pkginfo '{{ package }}'"
+  register: sas_svr4_present
+  changed_when: false
+  failed_when: false
+  when: sas_solaris_is_ips | bool
+
+- name: "flag {{ package }} as a genuine legacy SVR4 install"
+  set_fact:
+    sas_migrate_svr4: >-
+      {{ (sas_svr4_present.rc | default(1)) == 0
+         and (sas_ips_present.rc | default(1)) != 0 }}
+  when: sas_solaris_is_ips | bool
+
 # The admin file lets pkgadd/pkgrm run non-interactively while still executing
-# the SVR4 request script (unlike 'pkgadd -n'/'pkgrm -n').
+# the SVR4 request script (unlike 'pkgadd -n'/'pkgrm -n'). It is needed for the
+# Solaris 10 pkgadd and for the Solaris 11 SVR4 -> IPS migration pkgrm.
 - name: create SVR4 admin file
   copy:
     dest: "{{ package_dest_dir }}vas.admin"
@@ -57,7 +86,7 @@
   changed_when: false
   when: >-
     not (sas_solaris_is_ips | bool)
-    or sas_pkgsys == 'svr4'
+    or (sas_migrate_svr4 | default(false) | bool)
 
 # ------------------------------------------------------------------------------
 # Solaris 11+ : native IPS install (with legacy SVR4 -> IPS migration)
@@ -69,7 +98,7 @@
   changed_when: true
   when:
     - sas_solaris_is_ips | bool
-    - sas_pkgsys == 'svr4'
+    - sas_migrate_svr4 | default(false) | bool
 
 - name: "install {{ package }} from IPS archive"
   command:

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -1,8 +1,8 @@
 ---
 
-# One operation owns preflight, optional downgrade/SVR4-upgrade removal, native
-# install and archive cleanup. In particular, downgrade must not call remove.yml
-# before checking the linked-image publisher and the REQUIRED install media.
+# One operation owns preflight, optional Solaris 10 version-transition removal,
+# native install and archive cleanup. Required media and any linked-image
+# publisher checks must precede the install or genuine SVR4 migration removal.
 # Absent-only operations still call remove.yml directly, without media checks.
 - name: reset Solaris install operation state
   set_fact:
@@ -29,9 +29,9 @@
     - include_tasks: remove.yml
       when: sas_solaris_remove_before_install | default(false) | bool
 
-    # Keep the live pkg info/pkginfo probes in this helper AFTER an optional
-    # removal: cached version facts still describe the old SVR4 install during
-    # downgrade and must not cause a second pkgrm.
+    # Solaris 11 transitions do not call remove.yml. This helper's live
+    # pkg info/pkginfo probes authorise exactly one genuine SVR4 migration
+    # removal, never pkgrm based only on cached version facts.
     - include_tasks: install_package.yml
 
   always:

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -6,15 +6,19 @@
 # Branch on the OS major version:
 #
 #   * Solaris 11+ : install natively from the IPS archive discovered by
-#                   client_sw_pkgs (sas-*.p5p) with 'pkg install -g'. This runs
-#                   the IPS self-assembly that registers the SMF services (for
-#                   example svc:/quest/vas/vasd:default). If the package is
-#                   currently registered in the SVR4 database (a host installed
-#                   by an older release of this collection), the legacy .pkg is
-#                   removed first so the stale SVR4 registration and SMF state
-#                   are cleaned up before the IPS package is installed.
-#                   'pkg install -g' also upgrades an already-IPS package in
-#                   place, so the upgrade path reuses this file.
+#                   client_sw_pkgs (sas-*.p5p). Images without linked child
+#                   zones use the ephemeral 'pkg install -g' path. Since '-g'
+#                   is prohibited when linked non-global zones exist, those
+#                   images temporarily configure the archive as the sole
+#                   OneIdentity publisher origin, install the exact package
+#                   version, then restore the previous publisher state.
+#                   If the package is currently registered in the SVR4 database
+#                   (a host installed by an older release of this collection),
+#                   the legacy .pkg is removed first so the stale SVR4
+#                   registration and SMF state are cleaned up before the IPS
+#                   package is installed. The native install also upgrades an
+#                   already-IPS package in place, so the upgrade path reuses
+#                   this file.
 #
 #   * Solaris 10  : install the SVR4 package with an interactive pkgadd
 #                   (answering 'y', no '-n') so the SVR4 request script runs and
@@ -47,6 +51,7 @@
   register: sas_ips_present
   changed_when: false
   failed_when: false
+  check_mode: false
   environment:
     LC_ALL: C
   when: sas_solaris_is_ips | bool
@@ -57,6 +62,7 @@
   register: sas_svr4_present
   changed_when: false
   failed_when: false
+  check_mode: false
   environment:
     LC_ALL: C
   when: sas_solaris_is_ips | bool
@@ -147,7 +153,28 @@
     - sas_migrate_svr4 | default(false) | bool
     - sas_svr4_migrate.rc | default(0) in [2, 10, 20]
 
-- name: "install {{ package }} from IPS archive"
+# A per-operation '-g <archive>' origin is prohibited when the image has linked
+# children (non-global zones). Use it for ordinary images and reserve the more
+# invasive publisher transaction below for images that actually need it.
+- name: check for linked IPS child images
+  command:
+    cmd: "pkg list-linked -H"
+  register: sas_ips_linked_images
+  changed_when: false
+  check_mode: false
+  environment:
+    LC_ALL: C
+  when: sas_solaris_is_ips | bool
+
+- name: record linked IPS child image state
+  set_fact:
+    sas_solaris_has_linked_images: >-
+      {{ (sas_ips_linked_images.stdout | default('')
+          | regex_findall('(?m)^\S+\s+child\s+\S+')
+          | length) > 0 }}
+  when: sas_solaris_is_ips | bool
+
+- name: "install {{ package }} directly from IPS archive"
   command:
     cmd: "pkg install --accept -g '{{ package_dest }}' '{{ package }}'"
   register: pkg_install
@@ -156,7 +183,276 @@
   failed_when:
     - pkg_install.rc != 0
     - pkg_install.rc != 4
-  when: sas_solaris_is_ips | bool
+  when:
+    - sas_solaris_is_ips | bool
+    - not (sas_solaris_has_linked_images | bool)
+
+# Linked child images require the archive to be an ordinary publisher origin.
+# Snapshot the existing OneIdentity configuration, replace its origins for the
+# duration of the exact-version install, and attempt every restoration step in
+# an always block. Existing SSL-authenticated origins fail closed before any
+# mutation because removing an origin deletes IPS's private key/certificate
+# copies and the CLI has no lossless publisher export facility.
+- name: "install {{ package }} from IPS publisher for linked images"
+  block:
+
+    # These are host-scoped facts and install.yml is included once per package.
+    # Reset every per-operation value before any command can fail so the always
+    # cleanup cannot act on values left by a previous package iteration.
+    - name: reset temporary OneIdentity publisher operation state
+      set_fact:
+        sas_oneidentity_publisher_line: ""
+        sas_oneidentity_origin_lines: []
+        sas_oneidentity_publisher_exists: false
+        sas_oneidentity_publisher_enabled: true
+        sas_oneidentity_has_ssl_credentials: false
+        sas_oneidentity_origins_replaced: false
+        sas_oneidentity_publisher_temporarily_enabled: false
+        sas_oneidentity_cleanup_errors: []
+
+    - name: get current IPS publisher configuration
+      command:
+        cmd: "pkg publisher -H -F tsv"
+      register: sas_ips_publishers
+      changed_when: false
+      check_mode: false
+      environment:
+        LC_ALL: C
+
+    - name: record existing OneIdentity publisher line
+      set_fact:
+        sas_oneidentity_publisher_line: >-
+          {{ (sas_ips_publishers.stdout_lines | default([])
+              | select('match', '^OneIdentity\t')
+              | list | first | default('', true)) }}
+
+    # The TSV ENABLED column is unreliable for disabled publishers that still
+    # have origins on Solaris 11.4 (it remains "true"). The detail view's
+    # "Publisher enabled: Yes/No" value is authoritative.
+    - name: get current OneIdentity publisher properties
+      command:
+        cmd: "pkg publisher OneIdentity"
+      register: sas_oneidentity_publisher_details
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        LC_ALL: C
+      when: (sas_oneidentity_publisher_line | length) > 0
+
+    # 'pkg publisher' can return 3 for a certificate-expiry warning while still
+    # emitting the complete configuration. Accept that usable output, but fail
+    # closed if the expected identity/enabled fields are missing.
+    - name: verify OneIdentity publisher properties are conclusive
+      fail:
+        msg: >-
+          Could not read the complete OneIdentity publisher configuration:
+          {{ (sas_oneidentity_publisher_details.stderr | default('') | trim)
+             or ('pkg publisher exited '
+                 ~ (sas_oneidentity_publisher_details.rc | string)) }}
+      when:
+        - (sas_oneidentity_publisher_line | length) > 0
+        - >-
+          not (sas_oneidentity_publisher_details.stdout | default('')
+               is search('Publisher:\s+OneIdentity'))
+          or not (sas_oneidentity_publisher_details.stdout | default('')
+                  is search('(?:Publisher enabled|Enabled):\s+(?:Yes|No)'))
+
+    - name: record existing OneIdentity publisher state
+      set_fact:
+        sas_oneidentity_origin_lines: >-
+          {{ sas_ips_publishers.stdout_lines | default([])
+             | select('match', '^OneIdentity\t.*\torigin\t')
+             | list }}
+        sas_oneidentity_publisher_exists: >-
+          {{ (sas_oneidentity_publisher_line | length) > 0 }}
+        sas_oneidentity_publisher_enabled: >-
+          {{ sas_oneidentity_publisher_details.stdout | default('')
+             is search('(?:Publisher enabled|Enabled):\s+Yes') }}
+        sas_oneidentity_has_ssl_credentials: >-
+          {{ sas_oneidentity_publisher_details.stdout | default('')
+             is search('SSL (?:Key|Cert):\s+(?!None(?:\s|$))\S+') }}
+
+    - name: reject unsafe replacement of SSL-authenticated publisher origins
+      fail:
+        msg: >-
+          Cannot install {{ package }} for linked IPS images because the
+          existing OneIdentity publisher uses SSL client credentials. Solaris
+          deletes its private credential copies when origins are removed, so
+          the publisher cannot be restored losslessly. Remove or separately
+          preserve that publisher configuration before running this role.
+      when:
+        - sas_oneidentity_publisher_exists | bool
+        - sas_oneidentity_has_ssl_credentials | bool
+
+    # Origins under one IPS publisher are replicas, not ordered alternatives.
+    # Replace every existing origin so IPS can only fetch the requested build
+    # from package_dest; restore the full original list in the always block.
+    - name: temporarily replace OneIdentity publisher origins
+      command:
+        cmd: >-
+          pkg set-publisher
+          {{ "-G '*' " if sas_oneidentity_publisher_exists | bool else "" }}
+          -g '{{ package_dest }}' OneIdentity
+      register: sas_oneidentity_origins_replace
+      changed_when: false
+
+    - name: record replaced OneIdentity publisher origins
+      set_fact:
+        sas_oneidentity_origins_replaced: true
+      when:
+        - sas_oneidentity_origins_replace is defined
+        - not (sas_oneidentity_origins_replace.skipped | default(false))
+        - (sas_oneidentity_origins_replace.rc | default(1)) == 0
+
+    # Replace origins before enabling a disabled publisher. A publisher is often
+    # disabled because its old origin is unreachable; enabling first could
+    # refresh that bad origin and fail before the supplied archive is configured.
+    - name: temporarily enable the OneIdentity publisher
+      command:
+        cmd: "pkg set-publisher --enable OneIdentity"
+      register: sas_oneidentity_publisher_enable
+      changed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | bool
+        - not (sas_oneidentity_publisher_enabled | bool)
+
+    - name: record temporarily enabled OneIdentity publisher
+      set_fact:
+        sas_oneidentity_publisher_temporarily_enabled: true
+      when:
+        - sas_oneidentity_publisher_enable is defined
+        - not (sas_oneidentity_publisher_enable.skipped | default(false))
+        - (sas_oneidentity_publisher_enable.rc | default(1)) == 0
+
+    - name: "install {{ package }} from configured IPS publisher"
+      command:
+        cmd: >-
+          pkg install --accept
+          'pkg://OneIdentity/{{ package }}@{{ client_sw_pkgs['packages'][package]['vers'] }}'
+      register: pkg_install
+      changed_when: pkg_install.rc == 0
+      # pkg rc 4 == "nothing to do" (already at the requested version)
+      failed_when:
+        - pkg_install.rc != 0
+        - pkg_install.rc != 4
+
+  always:
+
+    # Restore an originally disabled publisher before adding its old origins.
+    # This prevents IPS from refreshing intentionally unreachable origins.
+    - name: restore the disabled OneIdentity publisher
+      command:
+        cmd: "pkg set-publisher --disable OneIdentity"
+      register: sas_oneidentity_publisher_disable
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_publisher_temporarily_enabled | default(false) | bool
+
+    - name: record OneIdentity publisher disable failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not restore disabled OneIdentity publisher'
+                ~ ' (rc=' ~ (sas_oneidentity_publisher_disable.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_publisher_disable is defined
+        - not (sas_oneidentity_publisher_disable.skipped | default(false))
+        - (sas_oneidentity_publisher_disable.rc | default(0)) != 0
+
+    - name: remove the temporary OneIdentity publisher origins
+      command:
+        cmd: "pkg set-publisher --no-refresh -G '*' OneIdentity"
+      register: sas_oneidentity_origins_remove
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_origins_replaced | default(false) | bool
+
+    - name: record temporary OneIdentity origins cleanup failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not remove temporary OneIdentity origins'
+                ~ ' (rc=' ~ (sas_oneidentity_origins_remove.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_origins_remove is defined
+        - not (sas_oneidentity_origins_remove.skipped | default(false))
+        - (sas_oneidentity_origins_remove.rc | default(0)) != 0
+
+    - name: restore OneIdentity publisher origins
+      command:
+        cmd: >-
+          pkg set-publisher --no-refresh
+          {{ "--disable"
+             if sas_oneidentity_origin_fields[3] == 'false'
+             else "" }}
+          -g '{{ sas_oneidentity_origin_fields[6] }}'
+          {{ "--proxy '" ~ sas_oneidentity_origin_fields[7] ~ "'"
+             if (sas_oneidentity_origin_fields | length) > 7
+                and sas_oneidentity_origin_fields[7] not in ['', '-']
+             else "" }}
+          OneIdentity
+      loop: "{{ sas_oneidentity_origin_lines | default([]) }}"
+      loop_control:
+        loop_var: sas_oneidentity_origin_line
+      register: sas_oneidentity_origins_restore
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_origins_replaced | default(false) | bool
+      vars:
+        sas_oneidentity_origin_fields: "{{ sas_oneidentity_origin_line.split('\t') }}"
+
+    - name: record OneIdentity publisher origin restore failures
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not restore OneIdentity origin '
+                ~ sas_oneidentity_origin_result.sas_oneidentity_origin_line.split('\t')[6]
+                ~ ' (rc=' ~ (sas_oneidentity_origin_result.rc | string) ~ ')'] }}
+      loop: "{{ sas_oneidentity_origins_restore.results | default([]) }}"
+      loop_control:
+        loop_var: sas_oneidentity_origin_result
+      when:
+        - not (sas_oneidentity_origin_result.skipped | default(false))
+        - (sas_oneidentity_origin_result.rc | default(0)) != 0
+
+    - name: remove the temporary OneIdentity publisher
+      command:
+        cmd: "pkg unset-publisher OneIdentity"
+      register: sas_oneidentity_publisher_unset
+      changed_when: false
+      failed_when: false
+      when:
+        - not (sas_oneidentity_publisher_exists | default(true) | bool)
+        - sas_oneidentity_origins_replaced | default(false) | bool
+
+    - name: record temporary OneIdentity publisher cleanup failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not remove temporary OneIdentity publisher'
+                ~ ' (rc=' ~ (sas_oneidentity_publisher_unset.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_publisher_unset is defined
+        - not (sas_oneidentity_publisher_unset.skipped | default(false))
+        - (sas_oneidentity_publisher_unset.rc | default(0)) != 0
+
+    - name: fail if temporary OneIdentity publisher cleanup was incomplete
+      fail:
+        msg: >-
+          Failed to restore the OneIdentity IPS publisher configuration:
+          {{ sas_oneidentity_cleanup_errors | join('; ') }}
+      when: (sas_oneidentity_cleanup_errors | default([]) | length) > 0
+
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_solaris_has_linked_images | bool
 
 # ------------------------------------------------------------------------------
 # Solaris 10 : SVR4 install via interactive pkgadd

--- a/roles/client_sw/tasks/os/solaris/install.yml
+++ b/roles/client_sw/tasks/os/solaris/install.yml
@@ -2,25 +2,97 @@
 
 # ------------------------------------------------------------------------------
 # Solaris - install package
+#
+# Branch on the OS major version:
+#
+#   * Solaris 11+ : install natively from the IPS archive discovered by
+#                   client_sw_pkgs (sas-*.p5p) with 'pkg install -g'. This runs
+#                   the IPS self-assembly that registers the SMF services (for
+#                   example svc:/quest/vas/vasd:default). If the package is
+#                   currently registered in the SVR4 database (a host installed
+#                   by an older release of this collection), the legacy .pkg is
+#                   removed first so the stale SVR4 registration and SMF state
+#                   are cleaned up before the IPS package is installed.
+#                   'pkg install -g' also upgrades an already-IPS package in
+#                   place, so the upgrade path reuses this file.
+#
+#   * Solaris 10  : install the SVR4 package with an interactive pkgadd
+#                   (answering 'y', no '-n') so the SVR4 request script runs and
+#                   the postinstall registers the service. The 'svr4pkg' module
+#                   runs 'pkgadd -n', which skips the request script that sets
+#                   $SERVICES/$CLASSES, leaving the service unregistered.
 # ------------------------------------------------------------------------------
 
-# Package install, copy installer
+- name: set Authentication Services Solaris packaging facts
+  set_fact:
+    sas_solaris_is_ips: >-
+      {{ ansible_facts['distribution_major_version']
+         is version('11', '>=') }}
+    sas_pkgsys: >-
+      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_pkgsys']
+         | default('') }}
+
+# Copy the discovered install archive/package to the target. On Solaris 11 this
+# is the shared sas-*.p5p; on Solaris 10 it is the per-package .pkg.
 - include_tasks: package_copy.yml
 
-# Package install, make response file
-- copy:
-    content: 'y\n'
-    dest: "{{ package_dest_dir }}/install.response"
+# The admin file lets pkgadd/pkgrm run non-interactively while still executing
+# the SVR4 request script (unlike 'pkgadd -n'/'pkgrm -n').
+- name: create SVR4 admin file
+  copy:
+    dest: "{{ package_dest_dir }}vas.admin"
+    mode: "0644"
+    content: |
+      mail=
+      instance=overwrite
+      partial=nocheck
+      runlevel=nocheck
+      idepend=nocheck
+      rdepend=nocheck
+      space=nocheck
+      setuid=nocheck
+      conflict=nocheck
+      action=nocheck
+      basedir=default
   changed_when: false
-  ignore_errors: true
+  when: >-
+    not (sas_solaris_is_ips | bool)
+    or sas_pkgsys == 'svr4'
 
-# Package install
-- name: install {{ package }}
-  svr4pkg:
-    name: "{{ package }}"
-    state: present 
-    src: "{{ package_dest }}"
-    response_file: "{{ package_dest_dir }}/install.response" 
-  #command:
-  #  cmd: pkgadd -d {{ package_dest }} -r {{ package_dest_dir }}/install.response all
-  register: pkg_install 
+# ------------------------------------------------------------------------------
+# Solaris 11+ : native IPS install (with legacy SVR4 -> IPS migration)
+# ------------------------------------------------------------------------------
+- name: "migrate legacy SVR4 {{ package }} to IPS"
+  shell:
+    cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
+  register: sas_svr4_migrate
+  changed_when: true
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_pkgsys == 'svr4'
+
+- name: "install {{ package }} from IPS archive"
+  command:
+    cmd: "pkg install --accept -g '{{ package_dest }}' '{{ package }}'"
+  register: pkg_install
+  changed_when: pkg_install.rc == 0
+  # pkg rc 4 == "nothing to do" (already at the requested version)
+  failed_when:
+    - pkg_install.rc != 0
+    - pkg_install.rc != 4
+  when: sas_solaris_is_ips | bool
+
+# ------------------------------------------------------------------------------
+# Solaris 10 : SVR4 install via interactive pkgadd
+# ------------------------------------------------------------------------------
+# NOTE: Do NOT use the 'svr4pkg' module here - it runs 'pkgadd -n' and the SVR4
+# request script (which sets $SERVICES/$CLASSES) is skipped, leaving vasd's SMF
+# service unregistered. 'yes |' answers the request script prompts.
+- name: "install {{ package }}"
+  shell:
+    cmd: >-
+      yes | pkgadd -a '{{ package_dest_dir }}vas.admin'
+      -G -d '{{ package_dest }}' '{{ package }}'
+  register: pkg_install
+  changed_when: pkg_install.rc == 0
+  when: not (sas_solaris_is_ips | bool)

--- a/roles/client_sw/tasks/os/solaris/install_package.yml
+++ b/roles/client_sw/tasks/os/solaris/install_package.yml
@@ -7,7 +7,7 @@
 #
 #   * Solaris 11+ : install natively from the IPS archive discovered by
 #                   client_sw_pkgs (sas-*.p5p). Images without linked child
-#                   zones use the ephemeral 'pkg install -g' path. Since '-g'
+#                   zones use a version-qualified 'pkg install -g'. Since '-g'
 #                   is prohibited when linked non-global zones exist, those
 #                   images temporarily configure the archive as the sole
 #                   OneIdentity publisher origin, install the exact package
@@ -16,9 +16,9 @@
 #                   (a host installed by an older release of this collection),
 #                   the legacy .pkg is removed first so the stale SVR4
 #                   registration and SMF state are cleaned up before the IPS
-#                   package is installed. The native install also upgrades an
-#                   already-IPS package in place, so the upgrade path reuses
-#                   this file.
+#                   package is installed. The native install also upgrades or
+#                   downgrades an already-IPS package in place, so both version
+#                   transitions reuse this file without uninstalling IPS first.
 #
 #   * Solaris 10  : install the SVR4 package with an interactive pkgadd
 #                   (answering 'y', no '-n') so the SVR4 request script runs and
@@ -29,12 +29,11 @@
 
 # On Solaris 11, decide whether a GENUINE legacy SVR4 install must be removed
 # before the IPS install. Probe the LIVE state (rather than a cached fact) so
-# this is idempotent - it is safe to run this file more than once for the same
-# package (for example the downgrade path removes the package first, then
-# installs). A package is a genuine legacy SVR4 install only when 'pkginfo'
+# this is idempotent - reruns must not repeat a completed migration removal.
+# A package is a genuine legacy SVR4 install only when 'pkginfo'
 # finds it AND 'pkg info' does not: on Solaris 11 'pkginfo' also lists IPS
 # packages, so probing 'pkginfo' alone would pkgrm the live IPS package on an
-# ordinary reinstall/upgrade.
+# ordinary reinstall/upgrade/downgrade.
 - name: "check {{ package }} IPS registration"
   command:
     cmd: "pkg info '{{ package }}'"
@@ -145,7 +144,11 @@
 
 - name: "install {{ package }} directly from IPS archive"
   command:
-    cmd: "pkg install --accept -g '{{ package_dest }}' '{{ package }}'"
+    # -g adds a source; it does not exclude newer configured catalog releases.
+    # Match the linked path's publisher/release constraint, not just the name.
+    cmd: >-
+      pkg install --accept -g '{{ package_dest }}'
+      'pkg://OneIdentity/{{ package }}@{{ client_sw_pkgs['packages'][package]['vers'] }}'
   register: pkg_install
   changed_when: pkg_install.rc == 0
   # pkg rc 4 == "nothing to do" (already at the requested version)

--- a/roles/client_sw/tasks/os/solaris/install_package.yml
+++ b/roles/client_sw/tasks/os/solaris/install_package.yml
@@ -1,0 +1,390 @@
+---
+
+# ------------------------------------------------------------------------------
+# Solaris - install package after install.yml's eligibility/media preflight
+#
+# Branch on the OS major version:
+#
+#   * Solaris 11+ : install natively from the IPS archive discovered by
+#                   client_sw_pkgs (sas-*.p5p). Images without linked child
+#                   zones use the ephemeral 'pkg install -g' path. Since '-g'
+#                   is prohibited when linked non-global zones exist, those
+#                   images temporarily configure the archive as the sole
+#                   OneIdentity publisher origin, install the exact package
+#                   version, then restore the previous publisher state.
+#                   If the package is currently registered in the SVR4 database
+#                   (a host installed by an older release of this collection),
+#                   the legacy .pkg is removed first so the stale SVR4
+#                   registration and SMF state are cleaned up before the IPS
+#                   package is installed. The native install also upgrades an
+#                   already-IPS package in place, so the upgrade path reuses
+#                   this file.
+#
+#   * Solaris 10  : install the SVR4 package with an interactive pkgadd
+#                   (answering 'y', no '-n') so the SVR4 request script runs and
+#                   the postinstall registers the service. The 'svr4pkg' module
+#                   runs 'pkgadd -n', which skips the request script that sets
+#                   $SERVICES/$CLASSES, leaving the service unregistered.
+# ------------------------------------------------------------------------------
+
+# On Solaris 11, decide whether a GENUINE legacy SVR4 install must be removed
+# before the IPS install. Probe the LIVE state (rather than a cached fact) so
+# this is idempotent - it is safe to run this file more than once for the same
+# package (for example the downgrade path removes the package first, then
+# installs). A package is a genuine legacy SVR4 install only when 'pkginfo'
+# finds it AND 'pkg info' does not: on Solaris 11 'pkginfo' also lists IPS
+# packages, so probing 'pkginfo' alone would pkgrm the live IPS package on an
+# ordinary reinstall/upgrade.
+- name: "check {{ package }} IPS registration"
+  command:
+    cmd: "pkg info '{{ package }}'"
+  register: sas_ips_present
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  environment:
+    LC_ALL: C
+  when: sas_solaris_is_ips | bool
+
+- name: "check {{ package }} SVR4 registration"
+  command:
+    cmd: "pkginfo '{{ package }}'"
+  register: sas_svr4_present
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  environment:
+    LC_ALL: C
+  when: sas_solaris_is_ips | bool
+
+# Fail closed on an inconclusive probe: only the recognised not-installed
+# message may authorise treating a database as empty. An operational error must
+# not be read as "IPS absent" and let the migration pkgrm below remove a live
+# IPS package.
+- name: "verify {{ package }} IPS probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the IPS registration of {{ package }}: 'pkg info'
+      exited {{ sas_ips_present.rc }} with unexpected output -
+      {{ (sas_ips_present.stderr | default('') | trim)
+         or (sas_ips_present.stdout | default('') | trim) }}
+  when:
+    - sas_solaris_is_ips | bool
+    - (sas_ips_present.rc | default(1)) != 0
+    - not (sas_ips_present.stderr | default('') is search('no packages matching'))
+
+- name: "verify {{ package }} SVR4 probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the SVR4 registration of {{ package }}: 'pkginfo'
+      exited {{ sas_svr4_present.rc }} with unexpected output -
+      {{ (sas_svr4_present.stderr | default('') | trim)
+         or (sas_svr4_present.stdout | default('') | trim) }}
+  when:
+    - sas_solaris_is_ips | bool
+    - (sas_svr4_present.rc | default(1)) != 0
+    - not (sas_svr4_present.stderr | default('') is search('was not found'))
+
+- name: "flag {{ package }} as a genuine legacy SVR4 install"
+  set_fact:
+    sas_migrate_svr4: >-
+      {{ (sas_svr4_present.rc | default(1)) == 0
+         and (sas_ips_present.rc | default(1)) != 0 }}
+  when: sas_solaris_is_ips | bool
+
+# The admin file lets pkgadd/pkgrm run non-interactively while still executing
+# the SVR4 request script (unlike 'pkgadd -n'/'pkgrm -n'). It is needed for the
+# Solaris 10 pkgadd and for the Solaris 11 SVR4 -> IPS migration pkgrm.
+- name: create SVR4 admin file
+  copy:
+    dest: "{{ package_dest_dir }}vas.admin"
+    mode: "0644"
+    content: |
+      mail=
+      instance=overwrite
+      partial=nocheck
+      runlevel=nocheck
+      idepend=nocheck
+      rdepend=nocheck
+      space=nocheck
+      setuid=nocheck
+      conflict=nocheck
+      action=nocheck
+      basedir=default
+  changed_when: false
+  when: >-
+    not (sas_solaris_is_ips | bool)
+    or (sas_migrate_svr4 | default(false) | bool)
+
+# ------------------------------------------------------------------------------
+# Solaris 11+ : native IPS install (with legacy SVR4 -> IPS migration)
+# ------------------------------------------------------------------------------
+- name: "migrate legacy SVR4 {{ package }} to IPS"
+  shell:
+    cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
+  register: sas_svr4_migrate
+  # pkgrm(1M) documents 2 (warning) and 10/20 (reboot required) as completed
+  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
+  # so a completed removal is not sent to 'rescue'.
+  changed_when: sas_svr4_migrate.rc in [0, 2, 10, 20]
+  failed_when: sas_svr4_migrate.rc not in [0, 2, 10, 20]
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_migrate_svr4 | default(false) | bool
+
+- name: "note {{ package }} SVR4 removal reboot/warning status"
+  debug:
+    msg: >-
+      pkgrm for {{ package }} completed with return code
+      {{ sas_svr4_migrate.rc }}
+      ({{ 'reboot required' if sas_svr4_migrate.rc in [10, 20] else 'warning' }}).
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_migrate_svr4 | default(false) | bool
+    - sas_svr4_migrate.rc | default(0) in [2, 10, 20]
+
+- name: "install {{ package }} directly from IPS archive"
+  command:
+    cmd: "pkg install --accept -g '{{ package_dest }}' '{{ package }}'"
+  register: pkg_install
+  changed_when: pkg_install.rc == 0
+  # pkg rc 4 == "nothing to do" (already at the requested version)
+  failed_when:
+    - pkg_install.rc != 0
+    - pkg_install.rc != 4
+  when:
+    - sas_solaris_is_ips | bool
+    - not (sas_solaris_has_linked_images | bool)
+
+# Linked child images require the archive to be an ordinary publisher origin.
+# Preflight has already snapshotted and checked the OneIdentity configuration
+# and verified the staged archive as pkg5srv, BEFORE any package removal.
+# Replace the origins for the exact-version install and retain the existing
+# always transaction to restore every origin, proxy and enabled state.
+- name: "install {{ package }} from IPS publisher for linked images"
+  block:
+
+    # Conservatively retain the archive even if set-publisher fails partway
+    # through. It may have registered the origin before reporting an error.
+    - name: retain staged IPS archive until publisher use is finished
+      set_fact:
+        sas_ips_archive_in_use: true
+
+    # Origins under one IPS publisher are replicas, not ordered alternatives.
+    # Replace every existing origin so IPS can only fetch the requested build
+    # from the worker-readable stage; restore the list in the always block.
+    - name: temporarily replace OneIdentity publisher origins
+      command:
+        cmd: >-
+          pkg set-publisher
+          {{ "-G '*' " if sas_oneidentity_publisher_exists | bool else "" }}
+          -g '{{ sas_ips_stage.path }}/archive.p5p' OneIdentity
+      register: sas_oneidentity_origins_replace
+      changed_when: false
+
+    - name: record replaced OneIdentity publisher origins
+      set_fact:
+        sas_oneidentity_origins_replaced: true
+      when:
+        - sas_oneidentity_origins_replace is defined
+        - not (sas_oneidentity_origins_replace.skipped | default(false))
+        - (sas_oneidentity_origins_replace.rc | default(1)) == 0
+
+    # Replace origins before enabling a disabled publisher. A publisher is often
+    # disabled because its old origin is unreachable; enabling first could
+    # refresh that bad origin and fail before the supplied archive is configured.
+    - name: temporarily enable the OneIdentity publisher
+      command:
+        cmd: "pkg set-publisher --enable OneIdentity"
+      register: sas_oneidentity_publisher_enable
+      changed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | bool
+        - not (sas_oneidentity_publisher_enabled | bool)
+
+    - name: record temporarily enabled OneIdentity publisher
+      set_fact:
+        sas_oneidentity_publisher_temporarily_enabled: true
+      when:
+        - sas_oneidentity_publisher_enable is defined
+        - not (sas_oneidentity_publisher_enable.skipped | default(false))
+        - (sas_oneidentity_publisher_enable.rc | default(1)) == 0
+
+    - name: "install {{ package }} from configured IPS publisher"
+      command:
+        cmd: >-
+          pkg install --accept
+          'pkg://OneIdentity/{{ package }}@{{ client_sw_pkgs['packages'][package]['vers'] }}'
+      register: pkg_install
+      changed_when: pkg_install.rc == 0
+      # pkg rc 4 == "nothing to do" (already at the requested version)
+      failed_when:
+        - pkg_install.rc != 0
+        - pkg_install.rc != 4
+
+  always:
+
+    # Restore an originally disabled publisher before adding its old origins.
+    # This prevents IPS from refreshing intentionally unreachable origins.
+    - name: restore the disabled OneIdentity publisher
+      command:
+        cmd: "pkg set-publisher --disable OneIdentity"
+      register: sas_oneidentity_publisher_disable
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_publisher_temporarily_enabled | default(false) | bool
+
+    - name: record OneIdentity publisher disable failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not restore disabled OneIdentity publisher'
+                ~ ' (rc=' ~ (sas_oneidentity_publisher_disable.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_publisher_disable is defined
+        - not (sas_oneidentity_publisher_disable.skipped | default(false))
+        - (sas_oneidentity_publisher_disable.rc | default(0)) != 0
+
+    - name: remove the temporary OneIdentity publisher origins
+      command:
+        cmd: "pkg set-publisher --no-refresh -G '*' OneIdentity"
+      register: sas_oneidentity_origins_remove
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_origins_replaced | default(false) | bool
+
+    # Release the stage as soon as its origin is detached. A later failure
+    # restoring an old origin must not leak an archive no publisher uses.
+    - name: release staged IPS archive after removing its temporary origin
+      set_fact:
+        sas_ips_archive_in_use: false
+      when:
+        - not (sas_oneidentity_origins_remove.skipped | default(false))
+        - (sas_oneidentity_origins_remove.rc | default(1)) == 0
+
+    - name: record temporary OneIdentity origins cleanup failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not remove temporary OneIdentity origins'
+                ~ ' (rc=' ~ (sas_oneidentity_origins_remove.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_origins_remove is defined
+        - not (sas_oneidentity_origins_remove.skipped | default(false))
+        - (sas_oneidentity_origins_remove.rc | default(0)) != 0
+
+    - name: restore OneIdentity publisher origins
+      command:
+        cmd: >-
+          pkg set-publisher --no-refresh
+          {{ "--disable"
+             if sas_oneidentity_origin_fields[3] == 'false'
+             else "" }}
+          -g '{{ sas_oneidentity_origin_fields[6] }}'
+          {{ "--proxy '" ~ sas_oneidentity_origin_fields[7] ~ "'"
+             if (sas_oneidentity_origin_fields | length) > 7
+                and sas_oneidentity_origin_fields[7] not in ['', '-']
+             else "" }}
+          OneIdentity
+      loop: "{{ sas_oneidentity_origin_lines | default([]) }}"
+      loop_control:
+        loop_var: sas_oneidentity_origin_line
+      register: sas_oneidentity_origins_restore
+      changed_when: false
+      failed_when: false
+      when:
+        - sas_oneidentity_publisher_exists | default(false) | bool
+        - sas_oneidentity_origins_replaced | default(false) | bool
+      vars:
+        sas_oneidentity_origin_fields: "{{ sas_oneidentity_origin_line.split('\t') }}"
+
+    - name: record OneIdentity publisher origin restore failures
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not restore OneIdentity origin '
+                ~ sas_oneidentity_origin_result_fields[6]
+                ~ ' (rc=' ~ (sas_oneidentity_origin_result.rc | string) ~ ')'] }}
+      loop: "{{ sas_oneidentity_origins_restore.results | default([]) }}"
+      loop_control:
+        loop_var: sas_oneidentity_origin_result
+      when:
+        - not (sas_oneidentity_origin_result.skipped | default(false))
+        - (sas_oneidentity_origin_result.rc | default(0)) != 0
+      vars:
+        # Decode the TSV delimiter in YAML, as in the restoration loop above.
+        sas_oneidentity_origin_result_fields: "{{ sas_oneidentity_origin_result.sas_oneidentity_origin_line.split('\t') }}"
+
+    - name: remove the temporary OneIdentity publisher
+      command:
+        cmd: "pkg unset-publisher OneIdentity"
+      register: sas_oneidentity_publisher_unset
+      changed_when: false
+      failed_when: false
+      when:
+        - not (sas_oneidentity_publisher_exists | default(true) | bool)
+        - sas_oneidentity_origins_replaced | default(false) | bool
+
+    - name: record temporary OneIdentity publisher cleanup failure
+      set_fact:
+        sas_oneidentity_cleanup_errors: >-
+          {{ sas_oneidentity_cleanup_errors
+             + ['could not remove temporary OneIdentity publisher'
+                ~ ' (rc=' ~ (sas_oneidentity_publisher_unset.rc | string) ~ ')'] }}
+      when:
+        - sas_oneidentity_publisher_unset is defined
+        - not (sas_oneidentity_publisher_unset.skipped | default(false))
+        - (sas_oneidentity_publisher_unset.rc | default(0)) != 0
+
+    - name: release staged IPS archive after removing its temporary publisher
+      set_fact:
+        sas_ips_archive_in_use: false
+      when:
+        - not (sas_oneidentity_publisher_unset.skipped | default(false))
+        - (sas_oneidentity_publisher_unset.rc | default(1)) == 0
+
+    - name: fail if temporary OneIdentity publisher cleanup was incomplete
+      fail:
+        msg: >-
+          Failed to restore the OneIdentity IPS publisher configuration:
+          {{ sas_oneidentity_cleanup_errors | join('; ') }}
+      when: (sas_oneidentity_cleanup_errors | default([]) | length) > 0
+
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_solaris_has_linked_images | bool
+    # tempfile is deliberately not created in check mode; do not template a
+    # nonexistent path or run any part of the publisher mutation transaction.
+    - not ansible_check_mode
+
+# ------------------------------------------------------------------------------
+# Solaris 10 : SVR4 install via interactive pkgadd
+# ------------------------------------------------------------------------------
+# NOTE: Do NOT use the 'svr4pkg' module here - it runs 'pkgadd -n' and the SVR4
+# request script (which sets $SERVICES/$CLASSES) is skipped, leaving vasd's SMF
+# service unregistered. 'yes |' answers the request script prompts.
+- name: "install {{ package }}"
+  shell:
+    cmd: >-
+      yes | pkgadd -a '{{ package_dest_dir }}vas.admin'
+      -G -d '{{ package_dest }}' '{{ package }}'
+  register: pkg_install
+  # pkgadd(1M) documents 2 (warning) and 10/20 (reboot required) as completed
+  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
+  # so a completed install is not reported as a failure.
+  changed_when: pkg_install.rc in [0, 2, 10, 20]
+  failed_when: pkg_install.rc not in [0, 2, 10, 20]
+  when: not (sas_solaris_is_ips | bool)
+
+- name: "note {{ package }} pkgadd reboot/warning status"
+  debug:
+    msg: >-
+      pkgadd for {{ package }} completed with return code {{ pkg_install.rc }}
+      ({{ 'reboot required' if pkg_install.rc in [10, 20] else 'warning' }}).
+  when:
+    - not (sas_solaris_is_ips | bool)
+    - pkg_install.rc | default(0) in [2, 10, 20]

--- a/roles/client_sw/tasks/os/solaris/install_preflight.yml
+++ b/roles/client_sw/tasks/os/solaris/install_preflight.yml
@@ -1,8 +1,8 @@
 ---
 
 # All eligibility queries and required-media/access checks belong here, before
-# either migration pkgrm or downgrade remove.yml. No package/publisher mutation
-# is permitted in this helper.
+# native IPS install, migration pkgrm or Solaris 10 remove.yml. No
+# package/publisher mutation is permitted in this helper.
 
 # Only a CHILD relationship prohibits 'pkg install -g'. Parent/self rows do not.
 - name: check for linked IPS child images

--- a/roles/client_sw/tasks/os/solaris/install_preflight.yml
+++ b/roles/client_sw/tasks/os/solaris/install_preflight.yml
@@ -1,0 +1,199 @@
+---
+
+# All eligibility queries and required-media/access checks belong here, before
+# either migration pkgrm or downgrade remove.yml. No package/publisher mutation
+# is permitted in this helper.
+
+# Only a CHILD relationship prohibits 'pkg install -g'. Parent/self rows do not.
+- name: check for linked IPS child images
+  command:
+    cmd: "pkg list-linked -H"
+  register: sas_ips_linked_images
+  changed_when: false
+  check_mode: false
+  environment:
+    LC_ALL: C
+  when: sas_solaris_is_ips | bool
+
+- name: record linked IPS child image state
+  set_fact:
+    sas_solaris_has_linked_images: >-
+      {{ (sas_ips_linked_images.stdout | default('')
+          | regex_findall('(?m)^\S+\s+child\s+\S+')
+          | length) > 0 }}
+  when: sas_solaris_is_ips | bool
+
+- name: preflight OneIdentity publisher for linked IPS children
+  block:
+
+    - name: get current IPS publisher configuration
+      command:
+        cmd: "pkg publisher -H -F tsv"
+      register: sas_ips_publishers
+      changed_when: false
+      check_mode: false
+      environment:
+        LC_ALL: C
+
+    # PUBLISHER STICKY SYSPUB ENABLED TYPE STATUS URI [PROXY].
+    # ENABLED is per-origin, NOT the system/read-only publisher flag.
+    - name: verify OneIdentity publisher rows are conclusive
+      fail:
+        msg: Could not read the complete OneIdentity publisher TSV configuration.
+      loop: >-
+        {{ sas_ips_publishers.stdout_lines | default([])
+           | select('match', '^OneIdentity(?:\t|$)') | list }}
+      loop_control:
+        loop_var: sas_oneidentity_preflight_line
+      vars:
+        sas_oneidentity_preflight_fields: "{{ sas_oneidentity_preflight_line.split('\t') }}"
+      when: >-
+        (sas_oneidentity_preflight_fields | length) < 7
+        or sas_oneidentity_preflight_fields[2] not in ['true', 'false']
+        or sas_oneidentity_preflight_fields[3] not in ['true', 'false']
+
+    - name: reject replacement of system-managed OneIdentity publisher origins
+      fail:
+        msg: >-
+          Cannot install {{ package }} for linked IPS images because OneIdentity
+          is an inherited/system publisher (SYSPUB=true). Its read-only
+          configuration cannot be temporarily replaced and restored by this role.
+      when: >-
+        (sas_ips_publishers.stdout_lines | default([])
+         | select('match', '^OneIdentity\t[^\t]*\ttrue\t') | list | length) > 0
+
+    - name: record existing OneIdentity publisher line
+      set_fact:
+        sas_oneidentity_publisher_line: >-
+          {{ (sas_ips_publishers.stdout_lines | default([])
+              | select('match', '^OneIdentity\t')
+              | list | first | default('', true)) }}
+
+    # On Solaris 11.4 TSV ENABLED can still be true for a disabled publisher.
+    # The detail view is authoritative for the publisher-wide enabled state.
+    - name: get current OneIdentity publisher properties
+      command:
+        cmd: "pkg publisher OneIdentity"
+      register: sas_oneidentity_publisher_details
+      changed_when: false
+      failed_when: false
+      check_mode: false
+      environment:
+        LC_ALL: C
+      when: (sas_oneidentity_publisher_line | length) > 0
+
+    # Complete output accompanied by rc 3 (certificate warning) is usable.
+    # Other errors or missing identity/enabled fields must fail before removal.
+    - name: verify OneIdentity publisher properties are conclusive
+      fail:
+        msg: >-
+          Could not read the complete OneIdentity publisher configuration:
+          {{ (sas_oneidentity_publisher_details.stderr | default('') | trim)
+             or ('pkg publisher exited '
+                 ~ (sas_oneidentity_publisher_details.rc | string)) }}
+      when:
+        - (sas_oneidentity_publisher_line | length) > 0
+        - >-
+          (sas_oneidentity_publisher_details.rc | default(1)) not in [0, 3]
+          or not (sas_oneidentity_publisher_details.stdout | default('')
+                  is search('Publisher:\s+OneIdentity'))
+          or not (sas_oneidentity_publisher_details.stdout | default('')
+                  is search('(?:Publisher enabled|Enabled):\s+(?:Yes|No)'))
+
+    - name: record existing OneIdentity publisher state
+      set_fact:
+        sas_oneidentity_origin_lines: >-
+          {{ sas_ips_publishers.stdout_lines | default([])
+             | select('match', '^OneIdentity\t.*\torigin\t') | list }}
+        sas_oneidentity_publisher_exists: >-
+          {{ (sas_oneidentity_publisher_line | length) > 0 }}
+        sas_oneidentity_publisher_enabled: >-
+          {{ sas_oneidentity_publisher_details.stdout | default('')
+             is search('(?:Publisher enabled|Enabled):\s+Yes') }}
+        sas_oneidentity_has_ssl_credentials: >-
+          {{ sas_oneidentity_publisher_details.stdout | default('')
+             is search('SSL (?:Key|Cert):\s+(?!None(?:\s|$))\S+') }}
+
+    - name: reject unsafe replacement of SSL-authenticated publisher origins
+      fail:
+        msg: >-
+          Cannot install {{ package }} for linked IPS images because the
+          existing OneIdentity publisher uses SSL client credentials. Solaris
+          deletes its private credential copies when origins are removed, so
+          the publisher cannot be restored losslessly. Remove or separately
+          preserve that publisher configuration before running this role.
+      when:
+        - sas_oneidentity_publisher_exists | bool
+        - sas_oneidentity_has_ssl_credentials | bool
+
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_solaris_has_linked_images | bool
+
+# Keep the existing media location for Solaris 10 and unlinked Solaris 11.
+# In check mode copy validates the controller source without creating a stage
+# (tempfile has no check-mode path); pkg5srv access is deferred to a real run.
+- include_tasks: package_copy.yml
+  when: >-
+    not (sas_solaris_is_ips | bool)
+    or not (sas_solaris_has_linked_images | bool)
+    or ansible_check_mode
+
+- name: stage and verify linked IPS archive before package removal
+  block:
+
+    # Do not use/chmod client_sw_tmp_dir's caller-owned ancestors. mkdtemp
+    # creates a unique owned directory; 0755 permits search without write access.
+    - name: allocate this operation's linked IPS archive directory
+      tempfile:
+        state: directory
+        path: /var/tmp
+        prefix: ansible-as-ips-
+      register: sas_ips_stage
+      changed_when: false
+
+    - name: make owned IPS archive directory searchable by pkg5srv
+      file:
+        path: "{{ sas_ips_stage.path }}"
+        state: directory
+        owner: root
+        mode: "0755"
+      changed_when: false
+
+    - name: copy required IPS archive with deliberate worker-readable access
+      copy:
+        src: "{{ package_src }}"
+        dest: "{{ sas_ips_stage.path }}/archive.p5p"
+        owner: root
+        mode: "0644"
+      changed_when: false
+
+    # pkg5srv need not have a login shell or sudo access. Drop the subprocess's
+    # privileges before checking the entire path and reading the regular file;
+    # root's access (or file mode alone) cannot establish worker readability.
+    # Use only Python 2.6-compatible stdlib operations for historical targets.
+    - name: verify staged IPS archive access as the pkg5srv worker
+      command:
+        argv:
+          - "{{ ansible_facts['python']['executable'] }}"
+          - "-c"
+          - |
+            import os
+            import pwd
+            import stat
+            import sys
+            worker = pwd.getpwnam("pkg5srv")
+            os.setgroups([])
+            os.setgid(worker.pw_gid)
+            os.setuid(worker.pw_uid)
+            if not stat.S_ISREG(os.lstat(sys.argv[1]).st_mode):
+                sys.exit("The staged IPS archive is not a regular file")
+            with open(sys.argv[1], "rb") as archive:
+                archive.read(1)
+          - "{{ sas_ips_stage.path }}/archive.p5p"
+      changed_when: false
+
+  when:
+    - sas_solaris_is_ips | bool
+    - sas_solaris_has_linked_images | bool
+    - not ansible_check_mode

--- a/roles/client_sw/tasks/os/solaris/remove.yml
+++ b/roles/client_sw/tasks/os/solaris/remove.yml
@@ -2,12 +2,79 @@
 
 # ------------------------------------------------------------------------------
 # Solaris - remove package
+#
+# Remove with the tool that matches how the package is registered, not just the
+# OS version: a Solaris 11 host installed by an older release of this collection
+# is registered in the SVR4 database and must be removed with pkgrm, otherwise
+# 'pkg uninstall' is a no-op and the package is left behind.
+#
+#   * IPS  ('pkg uninstall')          - package registered in IPS
+#   * SVR4 (interactive 'pkgrm')       - package registered in SVR4 (Solaris 10,
+#                                        or a legacy install on Solaris 11)
+#
+# The interactive pkgrm (no '-n') runs the SVR4 preremove request script so the
+# SMF service is unregistered.
 # ------------------------------------------------------------------------------
 
-# Remove package
-- name: remove {{ package }}
-  svr4pkg:
-    name: "{{ package }}"
-    state: absent 
-  register: pkg_remove 
-  changed_when: true 
+- name: set Authentication Services Solaris packaging facts
+  set_fact:
+    sas_solaris_is_ips: >-
+      {{ ansible_facts['distribution_major_version']
+         is version('11', '>=') }}
+    sas_pkgsys: >-
+      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_pkgsys']
+         | default('') }}
+
+- name: set Solaris removal method
+  set_fact:
+    sas_remove_svr4: >-
+      {{ (not (sas_solaris_is_ips | bool)) or sas_pkgsys == 'svr4' }}
+
+# Package registered in IPS
+- name: "remove {{ package }} (IPS)"
+  command:
+    cmd: "pkg uninstall '{{ package }}'"
+  register: pkg_remove
+  changed_when: pkg_remove.rc == 0
+  # pkg rc 4 == "nothing to do" (package not installed)
+  failed_when:
+    - pkg_remove.rc != 0
+    - pkg_remove.rc != 4
+  when: not (sas_remove_svr4 | bool)
+
+# Package registered in SVR4 (Solaris 10, or a legacy Solaris 11 install).
+# temp_dir_create.yml only runs when a package is being installed, so an
+# absent-only playbook must ensure the admin-file directory exists here.
+- name: ensure SVR4 admin-file directory exists
+  file:
+    path: "{{ package_dest_dir }}"
+    state: directory
+    mode: "0755"
+  changed_when: false
+  when: sas_remove_svr4 | bool
+
+- name: create pkgrm admin file
+  copy:
+    dest: "{{ package_dest_dir }}vas.admin"
+    mode: "0644"
+    content: |
+      mail=
+      instance=overwrite
+      partial=nocheck
+      runlevel=nocheck
+      idepend=nocheck
+      rdepend=nocheck
+      space=nocheck
+      setuid=nocheck
+      conflict=nocheck
+      action=nocheck
+      basedir=default
+  changed_when: false
+  when: sas_remove_svr4 | bool
+
+- name: "remove {{ package }} (SVR4)"
+  shell:
+    cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
+  register: pkg_remove
+  changed_when: pkg_remove.rc == 0
+  when: sas_remove_svr4 | bool

--- a/roles/client_sw/tasks/os/solaris/remove.yml
+++ b/roles/client_sw/tasks/os/solaris/remove.yml
@@ -74,5 +74,18 @@
   shell:
     cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
   register: pkg_remove_svr4
-  changed_when: pkg_remove_svr4.rc == 0
+  # pkgrm(1M) documents 2 (warning) and 10/20 (reboot required) as completed
+  # outcomes in addition to 0; accept them (as community.general.svr4pkg does)
+  # so a completed removal is not reported as a failure.
+  changed_when: pkg_remove_svr4.rc in [0, 2, 10, 20]
+  failed_when: pkg_remove_svr4.rc not in [0, 2, 10, 20]
   when: sas_have_svr4 | bool
+
+- name: "note {{ package }} SVR4 removal reboot/warning status"
+  debug:
+    msg: >-
+      pkgrm for {{ package }} completed with return code {{ pkg_remove_svr4.rc }}
+      ({{ 'reboot required' if pkg_remove_svr4.rc in [10, 20] else 'warning' }}).
+  when:
+    - sas_have_svr4 | bool
+    - pkg_remove_svr4.rc | default(0) in [2, 10, 20]

--- a/roles/client_sw/tasks/os/solaris/remove.yml
+++ b/roles/client_sw/tasks/os/solaris/remove.yml
@@ -4,13 +4,15 @@
 # Solaris - remove package
 #
 # Remove with the tool that matches how the package is registered, not just the
-# OS version: a Solaris 11 host installed by an older release of this collection
-# is registered in the SVR4 database and must be removed with pkgrm, otherwise
-# 'pkg uninstall' is a no-op and the package is left behind.
+# OS version. A Solaris 11 host installed by an older release of this collection
+# is registered in the SVR4 database and must be removed with pkgrm ('pkg
+# uninstall' is a no-op there). The version task classifies the install as IPS
+# or genuine legacy SVR4 (mutually exclusive - see version.yml for why 'pkginfo'
+# alone is not enough on Solaris 11), and the matching branch below runs.
 #
-#   * IPS  ('pkg uninstall')          - package registered in IPS
-#   * SVR4 (interactive 'pkgrm')       - package registered in SVR4 (Solaris 10,
-#                                        or a legacy install on Solaris 11)
+#   * IPS  ('pkg uninstall')     - runs when the package is an IPS install
+#   * SVR4 (interactive 'pkgrm')  - runs for a genuine legacy SVR4 install
+#                                   (Solaris 10, or a legacy Solaris 11 install)
 #
 # The interactive pkgrm (no '-n') runs the SVR4 preremove request script so the
 # SMF service is unregistered.
@@ -18,31 +20,27 @@
 
 - name: set Authentication Services Solaris packaging facts
   set_fact:
-    sas_solaris_is_ips: >-
-      {{ ansible_facts['distribution_major_version']
-         is version('11', '>=') }}
-    sas_pkgsys: >-
-      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_pkgsys']
-         | default('') }}
+    sas_have_ips: >-
+      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_ips']
+         | default(false) | bool }}
+    sas_have_svr4: >-
+      {{ hostvars[inventory_hostname]['sas_client_sw_' ~ package ~ '_svr4']
+         | default(false) | bool }}
 
-- name: set Solaris removal method
-  set_fact:
-    sas_remove_svr4: >-
-      {{ (not (sas_solaris_is_ips | bool)) or sas_pkgsys == 'svr4' }}
-
-# Package registered in IPS
+# IPS install -> 'pkg uninstall'.
 - name: "remove {{ package }} (IPS)"
   command:
     cmd: "pkg uninstall '{{ package }}'"
-  register: pkg_remove
-  changed_when: pkg_remove.rc == 0
+  register: pkg_remove_ips
+  changed_when: pkg_remove_ips.rc == 0
   # pkg rc 4 == "nothing to do" (package not installed)
   failed_when:
-    - pkg_remove.rc != 0
-    - pkg_remove.rc != 4
-  when: not (sas_remove_svr4 | bool)
+    - pkg_remove_ips.rc != 0
+    - pkg_remove_ips.rc != 4
+  when: sas_have_ips | bool
 
-# Package registered in SVR4 (Solaris 10, or a legacy Solaris 11 install).
+# Genuine legacy SVR4 install (Solaris 10, or a legacy Solaris 11 install) ->
+# interactive pkgrm so the preremove request script unregisters the SMF service.
 # temp_dir_create.yml only runs when a package is being installed, so an
 # absent-only playbook must ensure the admin-file directory exists here.
 - name: ensure SVR4 admin-file directory exists
@@ -51,7 +49,7 @@
     state: directory
     mode: "0755"
   changed_when: false
-  when: sas_remove_svr4 | bool
+  when: sas_have_svr4 | bool
 
 - name: create pkgrm admin file
   copy:
@@ -70,11 +68,11 @@
       action=nocheck
       basedir=default
   changed_when: false
-  when: sas_remove_svr4 | bool
+  when: sas_have_svr4 | bool
 
 - name: "remove {{ package }} (SVR4)"
   shell:
     cmd: "yes | pkgrm -a '{{ package_dest_dir }}vas.admin' '{{ package }}'"
-  register: pkg_remove
-  changed_when: pkg_remove.rc == 0
-  when: sas_remove_svr4 | bool
+  register: pkg_remove_svr4
+  changed_when: pkg_remove_svr4.rc == 0
+  when: sas_have_svr4 | bool

--- a/roles/client_sw/tasks/os/solaris/upgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/upgrade.yml
@@ -3,10 +3,10 @@
 # ------------------------------------------------------------------------------
 # Solaris - upgrade package
 #
-#   * Solaris 11+ : 'pkg install -g' performs the upgrade in place (and migrates
-#                   a legacy SVR4 install to IPS), so reuse install.yml. This
-#                   avoids uninstalling a package before its dependents on the
-#                   native IPS path.
+#   * Solaris 11+ : the native IPS install performs the upgrade in place (and
+#                   migrates a legacy SVR4 install to IPS), so reuse install.yml.
+#                   This avoids uninstalling a package before its dependents on
+#                   the native IPS path.
 #   * Solaris 10  : SVR4 has no in-place upgrade, so remove then install.
 # ------------------------------------------------------------------------------
 

--- a/roles/client_sw/tasks/os/solaris/upgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/upgrade.yml
@@ -7,20 +7,11 @@
 #                   migrates a legacy SVR4 install to IPS), so reuse install.yml.
 #                   This avoids uninstalling a package before its dependents on
 #                   the native IPS path.
-#   * Solaris 10  : SVR4 has no in-place upgrade, so remove then install.
+#   * Solaris 10  : SVR4 has no in-place upgrade, so preflight media, remove,
+#                   then install within the same operation.
 # ------------------------------------------------------------------------------
 
-- name: set Authentication Services Solaris packaging facts
-  set_fact:
-    sas_solaris_is_ips: >-
-      {{ ansible_facts['distribution_major_version']
-         is version('11', '>=') }}
-
 - include_tasks: "install.yml"
-  when: sas_solaris_is_ips | bool
-
-- include_tasks: "remove.yml"
-  when: not (sas_solaris_is_ips | bool)
-
-- include_tasks: "install.yml"
-  when: not (sas_solaris_is_ips | bool)
+  vars:
+    sas_solaris_remove_before_install: >-
+      {{ ansible_facts['distribution_major_version'] is version('11', '<') }}

--- a/roles/client_sw/tasks/os/solaris/upgrade.yml
+++ b/roles/client_sw/tasks/os/solaris/upgrade.yml
@@ -2,7 +2,25 @@
 
 # ------------------------------------------------------------------------------
 # Solaris - upgrade package
+#
+#   * Solaris 11+ : 'pkg install -g' performs the upgrade in place (and migrates
+#                   a legacy SVR4 install to IPS), so reuse install.yml. This
+#                   avoids uninstalling a package before its dependents on the
+#                   native IPS path.
+#   * Solaris 10  : SVR4 has no in-place upgrade, so remove then install.
 # ------------------------------------------------------------------------------
 
-- include_tasks: "remove.yml"
+- name: set Authentication Services Solaris packaging facts
+  set_fact:
+    sas_solaris_is_ips: >-
+      {{ ansible_facts['distribution_major_version']
+         is version('11', '>=') }}
+
 - include_tasks: "install.yml"
+  when: sas_solaris_is_ips | bool
+
+- include_tasks: "remove.yml"
+  when: not (sas_solaris_is_ips | bool)
+
+- include_tasks: "install.yml"
+  when: not (sas_solaris_is_ips | bool)

--- a/roles/client_sw/tasks/os/solaris/version.yml
+++ b/roles/client_sw/tasks/os/solaris/version.yml
@@ -30,6 +30,7 @@
   register: sas_ips_info
   changed_when: false
   failed_when: false
+  check_mode: false
   environment:
     LC_ALL: C
   when: ansible_facts['distribution_major_version'] is version('11', '>=')
@@ -40,6 +41,7 @@
   register: sas_svr4_info
   changed_when: false
   failed_when: false
+  check_mode: false
   environment:
     LC_ALL: C
 

--- a/roles/client_sw/tasks/os/solaris/version.yml
+++ b/roles/client_sw/tasks/os/solaris/version.yml
@@ -1,14 +1,51 @@
 ---
 
 # ------------------------------------------------------------------------------
-# Solaris - grab package version 
+# Solaris - grab package version
+#
+# A host may have the package registered in either database:
+#   * IPS   ('pkg info')   - Solaris 11 native, installed by this role
+#   * SVR4  ('pkginfo')    - Solaris 10, or a Solaris 11 host installed by an
+#                            older version of this collection (legacy .pkg)
+#
+# Probe both, prefer IPS when present, and expose which packaging system holds
+# the package so the install/upgrade path can migrate a legacy SVR4 install to
+# IPS on Solaris 11. A clean version string is handed to set_version.yml via
+# pkg_version.stdout so the shared parser cannot latch onto an FMRI fragment
+# (e.g. the '5.11' build-branch component).
 # ------------------------------------------------------------------------------
 
-# Grab installed version of package 
-- name: get {{ package }} version
+- name: "get {{ package }} IPS version"
   command:
-    cmd: pkginfo -l {{ package }}
-  register: pkg_version
+    cmd: "pkg info {{ package }}"
+  register: sas_ips_info
   changed_when: false
   failed_when: false
-  ignore_errors: true
+  when: ansible_facts['distribution_major_version'] is version('11', '>=')
+
+- name: "get {{ package }} SVR4 version"
+  command:
+    cmd: "pkginfo -l {{ package }}"
+  register: sas_svr4_info
+  changed_when: false
+  failed_when: false
+
+- name: "determine {{ package }} version and packaging system"
+  set_fact:
+    sas_ips_ver: >-
+      {{ (sas_ips_info.stdout | default('', true)
+          | regex_findall('Version:\s*([0-9][0-9.]*)')
+          | first | default('', true))
+         if (sas_ips_info.rc | default(1)) == 0 else '' }}
+    sas_svr4_ver: >-
+      {{ (sas_svr4_info.stdout | default('', true)
+          | regex_findall('VERSION:\s*([0-9][0-9.]*)')
+          | first | default('', true))
+         if (sas_svr4_info.rc | default(1)) == 0 else '' }}
+
+- name: "record {{ package }} version and packaging system"
+  set_fact:
+    pkg_version:
+      stdout: "{{ sas_ips_ver if sas_ips_ver else sas_svr4_ver }}"
+    "sas_client_sw_{{ package }}_pkgsys": >-
+      {{ 'ips' if sas_ips_ver else ('svr4' if sas_svr4_ver else '') }}

--- a/roles/client_sw/tasks/os/solaris/version.yml
+++ b/roles/client_sw/tasks/os/solaris/version.yml
@@ -30,6 +30,8 @@
   register: sas_ips_info
   changed_when: false
   failed_when: false
+  environment:
+    LC_ALL: C
   when: ansible_facts['distribution_major_version'] is version('11', '>=')
 
 - name: "get {{ package }} SVR4 version"
@@ -38,6 +40,37 @@
   register: sas_svr4_info
   changed_when: false
   failed_when: false
+  environment:
+    LC_ALL: C
+
+# Distinguish "not installed" from an operational probe failure. Both 'pkg info'
+# and 'pkginfo' exit non-zero when the package is simply absent, but a transient
+# or operational error must NOT be read as absence: absence of IPS is later used
+# to authorise a migration pkgrm, so failing open here could remove a live IPS
+# package. Only the recognised not-installed message maps to absent; any other
+# non-zero result fails the role (LC_ALL=C above keeps these messages stable).
+- name: "verify {{ package }} IPS probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the IPS registration of {{ package }}: 'pkg info'
+      exited {{ sas_ips_info.rc }} with unexpected output -
+      {{ (sas_ips_info.stderr | default('') | trim)
+         or (sas_ips_info.stdout | default('') | trim) }}
+  when:
+    - ansible_facts['distribution_major_version'] is version('11', '>=')
+    - (sas_ips_info.rc | default(1)) != 0
+    - not (sas_ips_info.stderr | default('') is search('no packages matching'))
+
+- name: "verify {{ package }} SVR4 probe is conclusive"
+  fail:
+    msg: >-
+      Could not determine the SVR4 registration of {{ package }}: 'pkginfo'
+      exited {{ sas_svr4_info.rc }} with unexpected output -
+      {{ (sas_svr4_info.stderr | default('') | trim)
+         or (sas_svr4_info.stdout | default('') | trim) }}
+  when:
+    - (sas_svr4_info.rc | default(1)) != 0
+    - not (sas_svr4_info.stderr | default('') is search('was not found'))
 
 - name: "determine {{ package }} version and packaging system"
   set_fact:

--- a/roles/client_sw/tasks/os/solaris/version.yml
+++ b/roles/client_sw/tasks/os/solaris/version.yml
@@ -3,16 +3,25 @@
 # ------------------------------------------------------------------------------
 # Solaris - grab package version
 #
-# A host may have the package registered in either database:
+# A host may have the package registered as:
 #   * IPS   ('pkg info')   - Solaris 11 native, installed by this role
 #   * SVR4  ('pkginfo')    - Solaris 10, or a Solaris 11 host installed by an
 #                            older version of this collection (legacy .pkg)
 #
-# Probe both, prefer IPS when present, and expose which packaging system holds
-# the package so the install/upgrade path can migrate a legacy SVR4 install to
-# IPS on Solaris 11. A clean version string is handed to set_version.yml via
-# pkg_version.stdout so the shared parser cannot latch onto an FMRI fragment
-# (e.g. the '5.11' build-branch component).
+# IMPORTANT: on Solaris 11 the legacy 'pkginfo' command also reports IPS
+# packages (it is a compatibility VIEW over IPS, not a separate database):
+# 'pkginfo vasclnts' succeeds for an IPS install and stops succeeding once the
+# IPS package is uninstalled. 'pkginfo' therefore cannot be used on its own to
+# decide "is this a legacy SVR4 install". A package is treated as a GENUINE
+# legacy SVR4 install only when 'pkginfo' finds it AND 'pkg info' does NOT; when
+# 'pkg info' finds it the package is IPS and the 'pkginfo' hit is just the IPS
+# legacy view. This makes the two states mutually exclusive and keeps an
+# ordinary IPS install idempotent (otherwise every rerun would treat it as SVR4
+# and pkgrm the live IPS package).
+#
+# A clean version string is handed to set_version.yml via pkg_version.stdout so
+# the shared parser cannot latch onto an FMRI fragment (e.g. the '5.11'
+# build-branch component).
 # ------------------------------------------------------------------------------
 
 - name: "get {{ package }} IPS version"
@@ -37,15 +46,35 @@
           | regex_findall('Version:\s*([0-9][0-9.]*)')
           | first | default('', true))
          if (sas_ips_info.rc | default(1)) == 0 else '' }}
+    # A GENUINE legacy SVR4 install is one that 'pkginfo' finds but 'pkg info'
+    # does NOT - if IPS owns the package the 'pkginfo' hit is only the IPS
+    # legacy view (see the note above), so it is not a separate SVR4 install.
     sas_svr4_ver: >-
       {{ (sas_svr4_info.stdout | default('', true)
           | regex_findall('VERSION:\s*([0-9][0-9.]*)')
           | first | default('', true))
-         if (sas_svr4_info.rc | default(1)) == 0 else '' }}
+         if ((sas_svr4_info.rc | default(1)) == 0
+             and (sas_ips_info.rc | default(1)) != 0) else '' }}
 
 - name: "record {{ package }} version and packaging system"
   set_fact:
+    # IPS is preferred for routing; the two states are mutually exclusive so
+    # this only falls back to the SVR4 version for a genuine legacy install.
     pkg_version:
       stdout: "{{ sas_ips_ver if sas_ips_ver else sas_svr4_ver }}"
+    # Presence of each packaging system. 'svr4' means a genuine legacy SVR4
+    # install (pkginfo yes, pkg info no); an IPS install is 'ips' only, even
+    # though 'pkginfo' would also list it.
+    "sas_client_sw_{{ package }}_ips": "{{ (sas_ips_ver | length) > 0 }}"
+    "sas_client_sw_{{ package }}_svr4": "{{ (sas_svr4_ver | length) > 0 }}"
+    # 'ips', 'svr4' or '' - kept for reporting.
     "sas_client_sw_{{ package }}_pkgsys": >-
-      {{ 'ips' if sas_ips_ver else ('svr4' if sas_svr4_ver else '') }}
+      {{ 'ips' if sas_ips_ver
+         else ('svr4' if sas_svr4_ver else '') }}
+    # Migration is required only when a genuine legacy SVR4 install is present on
+    # a platform whose native system is IPS (Solaris 11). On Solaris 10 the
+    # native system is SVR4, so this is false and an equal-version rerun does
+    # nothing instead of reinstalling the SVR4 package on every run.
+    "sas_client_sw_{{ package }}_migrate": >-
+      {{ (ansible_facts['distribution_major_version'] is version('11', '>='))
+         and ((sas_svr4_ver | length) > 0) }}

--- a/roles/client_sw/tasks/run_package_task.yml
+++ b/roles/client_sw/tasks/run_package_task.yml
@@ -137,11 +137,15 @@
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] 
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] is version(client_sw_pkgs['packages'][package]['vers'], '>')
 
-# Handle migration (same version, but installed in a different packaging system)
-# Currently this covers a Solaris 11 host still registered in SVR4 from an older
+# Handle migration (installed version already matches the media, but the package
+# is registered in a packaging system that is not the platform's native one).
+# The OS version task sets '<pkg>_migrate' true only when such a conversion is
+# needed - currently a Solaris 11 host still registered in SVR4 from an older
 # release of this collection: the version matches the media so install/upgrade/
 # downgrade do not fire, but the package must still be migrated to the native
-# IPS package (the OS install task performs the SVR4 removal + IPS install).
+# IPS package (the OS install task performs the SVR4 removal + IPS install). On
+# Solaris 10 the native system is SVR4, so '<pkg>_migrate' is false there and an
+# equal-version rerun correctly does nothing.
 - name: migrate {{ package }}
   block:
 
@@ -167,7 +171,7 @@
   when:
     - package in client_sw_pkgs['packages']
     - state == 'present'
-    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_pkgsys'] | default('') == 'svr4'
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_migrate'] | default(false) | bool
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg']
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] is version(client_sw_pkgs['packages'][package]['vers'], '==')
 

--- a/roles/client_sw/tasks/run_package_task.yml
+++ b/roles/client_sw/tasks/run_package_task.yml
@@ -106,7 +106,7 @@
     - package in client_sw_pkgs['packages']
     - state == 'present'
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] 
-    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] < client_sw_pkgs['packages'][package]['vers']
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] is version(client_sw_pkgs['packages'][package]['vers'], '<')
 
 # Handle downgrade
 - name: downgrade {{ package }}
@@ -135,7 +135,41 @@
     - package in client_sw_pkgs['packages']
     - state == 'present'
     - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] 
-    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] > client_sw_pkgs['packages'][package]['vers']
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] is version(client_sw_pkgs['packages'][package]['vers'], '>')
+
+# Handle migration (same version, but installed in a different packaging system)
+# Currently this covers a Solaris 11 host still registered in SVR4 from an older
+# release of this collection: the version matches the media so install/upgrade/
+# downgrade do not fire, but the package must still be migrated to the native
+# IPS package (the OS install task performs the SVR4 removal + IPS install).
+- name: migrate {{ package }}
+  block:
+
+    - include_tasks: os/{{ ansible_facts['os_family'] | lower }}/install.yml
+
+    - include_tasks: utils/set_state.yml
+      vars:
+        flag: act
+        value: upgraded
+      when: client_sw_reports_generate or client_sw_facts_generate
+
+  rescue:
+
+    - include_tasks: utils/set_state.yml
+      vars:
+        flag: act
+        value: failed
+      when: client_sw_reports_generate or client_sw_facts_generate
+
+    - fail:
+        msg: failed to migrate {{ package }} package
+
+  when:
+    - package in client_sw_pkgs['packages']
+    - state == 'present'
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_pkgsys'] | default('') == 'svr4'
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg']
+    - hostvars[inventory_hostname]['sas_client_sw_' + package + '_vers_beg'] is version(client_sw_pkgs['packages'][package]['vers'], '==')
 
 # Handle no action 
 - include_tasks: utils/set_state.yml

--- a/tests/unit/plugins/modules/test_client_sw_pkgs.py
+++ b/tests/unit/plugins/modules/test_client_sw_pkgs.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# ------------------------------------------------------------------------------
+# Copyright (c) 2020, One Identity LLC
+# File: test_client_sw_pkgs.py
+# Desc: Unit tests for the client_sw_pkgs module Solaris IPS (.p5p) discovery
+#       helpers. Focus on failing discovery loudly for corrupt or incomplete
+#       media rather than silently skipping a requested package.
+# ------------------------------------------------------------------------------
+
+import io
+import os
+import importlib.util
+import tarfile
+import tempfile
+import shutil
+import unittest
+
+
+# ------------------------------------------------------------------------------
+# Load the module by path so the tests do not require the collection to be
+# installed into an ansible_collections tree.
+# ------------------------------------------------------------------------------
+_MODULE_PATH = os.path.join(
+    os.path.dirname(__file__),
+    '..', '..', '..', '..',
+    'plugins', 'modules', 'client_sw_pkgs.py'
+)
+
+_spec = importlib.util.spec_from_file_location('client_sw_pkgs', _MODULE_PATH)
+client_sw_pkgs = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(client_sw_pkgs)
+
+
+def _write_p5p(path, members):
+    """
+    Write a minimal USTAR .p5p tar. 'members' is a list of archive member
+    names; each is added as an empty file, mirroring how a real .p5p carries a
+    package manifest at publisher/<pub>/pkg/<name>/<encoded-version>.
+    """
+    with tarfile.open(path, 'w', format=tarfile.USTAR_FORMAT) as tar:
+        for name in members:
+            info = tarfile.TarInfo(name)
+            info.size = 0
+            tar.addfile(info, io.BytesIO(b''))
+
+
+class P5pPackagesTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_valid_archive_reports_real_version(self):
+        # The FMRI version is URL-encoded and carries the build branch after a
+        # comma; the release before the comma is what must be reported.
+        archive = os.path.join(self.tmp, 'sas.p5p')
+        _write_p5p(archive, [
+            'publisher/OneIdentity/pkg/vasclnts/1.2.3%2C5.11-0%3A20240101T000000Z',
+        ])
+        err, packages = client_sw_pkgs._p5p_packages(archive)
+        self.assertIsNone(err)
+        self.assertEqual(packages, {'vasclnts': '1.2.3'})
+
+    def test_highest_version_wins(self):
+        archive = os.path.join(self.tmp, 'sas.p5p')
+        _write_p5p(archive, [
+            'publisher/OneIdentity/pkg/vasclnt/1.2.3%2C5.11-0%3A20240101T000000Z',
+            'publisher/OneIdentity/pkg/vasclnt/1.10.0%2C5.11-0%3A20240201T000000Z',
+        ])
+        err, packages = client_sw_pkgs._p5p_packages(archive)
+        self.assertIsNone(err)
+        # Numeric (not lexical) comparison: 1.10.0 > 1.2.3.
+        self.assertEqual(packages, {'vasclnt': '1.10.0'})
+
+    def test_unreadable_archive_returns_error(self):
+        archive = os.path.join(self.tmp, 'corrupt.p5p')
+        with open(archive, 'wb') as handle:
+            handle.write(b'this is not a tar archive' * 8)
+        err, packages = client_sw_pkgs._p5p_packages(archive)
+        self.assertIsNotNone(err)
+        self.assertIn(archive, err)
+        self.assertEqual(packages, {})
+
+    def test_readable_but_empty_archive_returns_error(self):
+        # A tar-readable .p5p with no publisher/.../pkg/... manifests is
+        # incomplete media and must be reported, not treated as "no packages".
+        archive = os.path.join(self.tmp, 'empty.p5p')
+        _write_p5p(archive, ['pkg5.repository', 'publisher/OneIdentity/catalog/x'])
+        err, packages = client_sw_pkgs._p5p_packages(archive)
+        self.assertIsNotNone(err)
+        self.assertIn(archive, err)
+        self.assertEqual(packages, {})
+
+
+class FindPackagesSolarisIpsTests(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.base = os.path.join(self.tmp, 'solaris11-x64')
+        os.makedirs(self.base)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _valid(self, fname, pkg, vers):
+        _write_p5p(
+            os.path.join(self.base, fname),
+            ['publisher/OneIdentity/pkg/%s/%s%%2C5.11-0%%3A20240101T000000Z'
+             % (pkg, vers)]
+        )
+
+    def test_valid_only_discovers_package(self):
+        self._valid('sas.p5p', 'vasclnt', '7.1.0.6700')
+        err, packages = client_sw_pkgs.find_packages_solaris_ips(self.tmp, 'x64')
+        self.assertIsNone(err)
+        self.assertIn('vasclnt', packages)
+        self.assertEqual(packages['vasclnt']['vers'], '7.1.0.6700')
+
+    def test_corrupt_archive_fails_discovery(self):
+        self._valid('sas.p5p', 'vasclnt', '7.1.0.6700')
+        corrupt = os.path.join(self.base, 'sas_site.p5p')
+        with open(corrupt, 'wb') as handle:
+            handle.write(b'not a tar' * 8)
+        err, packages = client_sw_pkgs.find_packages_solaris_ips(self.tmp, 'x64')
+        self.assertIsNotNone(err)
+        self.assertIn('sas_site.p5p', err)
+        self.assertEqual(packages, {})
+
+    def test_empty_archive_fails_discovery(self):
+        # Regression: a valid standard archive beside a tar-readable but
+        # package-empty site archive must NOT pass discovery, otherwise a
+        # requested site package (e.g. vasclnts) is silently skipped.
+        self._valid('sas.p5p', 'vasclnt', '7.1.0.6700')
+        _write_p5p(os.path.join(self.base, 'sas_site.p5p'), ['pkg5.repository'])
+        err, packages = client_sw_pkgs.find_packages_solaris_ips(self.tmp, 'x64')
+        self.assertIsNotNone(err)
+        self.assertIn('sas_site.p5p', err)
+        self.assertEqual(packages, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/roles/client_sw/fixtures/solaris.yml
+++ b/tests/unit/roles/client_sw/fixtures/solaris.yml
@@ -1,0 +1,35 @@
+---
+
+# Only the production version/routing tasks are included, never gather_facts or
+# the role's main entry point. The test runner replaces all command/filesystem
+# actions with sandboxed stubs; this playbook MUST be run by the unittest.
+- hosts: localhost
+  gather_facts: false
+  vars:
+    ansible_facts:
+      os_family: Solaris
+      distribution_major_version: "{{ solaris_test_major }}"
+      python:
+        executable: "{{ solaris_test_python }}"
+    client_sw_tmp_dir: "{{ solaris_test_root }}/private"
+    client_sw_facts_generate: false
+    client_sw_reports_generate: false
+  tasks:
+    - name: read installed state with production version probes
+      include_role:
+        name: client_sw
+        tasks_from: read_package_version.yml
+      vars:
+        package: "{{ item.key }}"
+        state: "{{ item.value }}"
+        flag: beg
+      loop: "{{ solaris_test_packages }}"
+
+    - name: execute production install upgrade downgrade migration or removal
+      include_role:
+        name: client_sw
+        tasks_from: run_package_task.yml
+      vars:
+        package: "{{ item.key }}"
+        state: "{{ item.value }}"
+      loop: "{{ solaris_test_packages }}"

--- a/tests/unit/roles/client_sw/fixtures/solaris_actions.py
+++ b/tests/unit/roles/client_sw/fixtures/solaris_actions.py
@@ -262,10 +262,16 @@ class ActionModule(ActionBase):
         if "pkgadd" in argv or argv[:2] == ["pkg", "install"]:
             if fault == "install":
                 return self.result(1, stderr="stub package install error")
-            package = argv[-1].split("/")[-1].split("@")[0]
+            package, separator, requested_version = argv[-1].split("/")[-1].partition("@")
+            version = requested_version or self.state["target_version"]
+            # Model release selection only, not the full IPS solver. Adding
+            # an archive with -g leaves newer configured catalogs competing;
+            # only a version-qualified operand constrains the requested release.
+            if argv[:2] == ["pkg", "install"] and "-g" in argv and not separator:
+                version = self.state["newer_catalog_version"] or version
             self.state["installed"][package].update(
                 system="svr4" if "pkgadd" in argv else "ips",
-                version=self.state["target_version"],
+                version=version,
             )
             return self.result(self.state["svr4_rc"] if "pkgadd" in argv else 0)
 

--- a/tests/unit/roles/client_sw/fixtures/solaris_actions.py
+++ b/tests/unit/roles/client_sw/fixtures/solaris_actions.py
@@ -1,0 +1,297 @@
+"""Safe action stubs for executing the production Solaris task graph.
+
+No command is executed and no root privileges or Solaris installation is needed.
+Filesystem actions use real modes/files, but only below the unittest's sandbox;
+owner=root is recorded rather than chowning. tempfile's /var/tmp is mapped to a
+searchable sibling of the restrictive caller directory. The production worker
+probe is executed with only its identity-changing calls replaced.
+"""
+
+import builtins
+import json
+import os
+import shlex
+import shutil
+import stat
+import tempfile
+import types
+
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        super(ActionModule, self).run(tmp, task_vars)
+        self.root = task_vars["solaris_test_root"]
+        state_path = os.path.join(self.root, "state.json")
+        with open(state_path) as handle:
+            self.state = json.load(handle)
+        self.args = dict(self._task.args)
+        self.check = bool(self._task.check_mode)
+        action = self._task.action.split(".")[-1]
+        self.event = {
+            "action": action,
+            "task": self._task.get_name(),
+            "args": self.args,
+            "check": self.check,
+        }
+        self.state["events"].append(self.event)
+        try:
+            result = getattr(self, "stub_" + action)()
+        except Exception as error:
+            result = {
+                "failed": True, "changed": False, "rc": 1,
+                "msg": str(error), "stdout": "", "stderr": str(error),
+            }
+        finally:
+            with open(state_path, "w") as handle:
+                json.dump(self.state, handle)
+        return result
+
+    def safe_path(self, path):
+        if os.path.commonpath([os.path.realpath(path), self.root]) != self.root:
+            raise AssertionError("Action attempted to leave the test sandbox")
+        return path
+
+    @staticmethod
+    def result(rc=0, stdout="", stderr=""):
+        return {
+            "changed": False, "rc": rc, "stdout": stdout,
+            "stdout_lines": stdout.splitlines(), "stderr": stderr,
+            "stderr_lines": stderr.splitlines(), "failed": rc != 0,
+        }
+
+    def stub_tempfile(self):
+        assert self.args["state"] == "directory"
+        assert self.args["path"] == "/var/tmp"
+        assert self.args["prefix"] == "ansible-as-ips-"
+        if self.check:
+            return {"changed": False, "skipped": True}  # Deliberately no path.
+        if self.state["fault"] == "tempfile":
+            raise OSError("stub stage allocation error")
+        path = tempfile.mkdtemp(
+            prefix=self.args["prefix"],
+            dir=os.path.join(self.root, "stage-root"),
+        )
+        self.state["stages"].append(path)
+        return {"changed": True, "path": path}
+
+    def stub_file(self):
+        path = self.safe_path(self.args["path"])
+        if self.check:
+            return {"changed": not os.path.exists(path)}
+        if self.args["state"] == "absent":
+            assert path in self.state["stages"], "Cleanup did not own this path"
+            assert self.state["temp_origin"] != path + "/archive.p5p", (
+                "Cleanup deleted an archive still used by the publisher"
+            )
+            shutil.rmtree(path)
+            self.state["cleaned"].append(path)
+        else:
+            assert self.args["state"] == "directory"
+            os.makedirs(path, exist_ok=True)
+            if "mode" in self.args:
+                os.chmod(path, int(self.args["mode"], 8))
+            self.event["mode"] = stat.S_IMODE(os.stat(path).st_mode)
+        return {"changed": True}
+
+    def stub_copy(self):
+        path = self.safe_path(self.args["dest"])
+        if "src" in self.args:
+            source = self.safe_path(self.args["src"])
+            if not os.path.isfile(source):
+                raise OSError("stub required media missing")
+        if self.check:
+            return {"changed": True}
+        if (self.state["fault"] == "copy"
+                and os.path.dirname(path) in self.state["stages"]):
+            raise OSError("stub required archive copy error")
+        if "src" in self.args:
+            shutil.copyfile(source, path)
+        else:
+            with open(path, "w") as handle:
+                handle.write(self.args["content"])
+        if "mode" in self.args:
+            os.chmod(path, int(self.args["mode"], 8))
+        self.event["mode"] = stat.S_IMODE(os.stat(path).st_mode)
+        return {"changed": True}
+
+    def worker_probe(self, script, path):
+        """Execute the real probe without changing the test runner's identity."""
+        self.safe_path(path)
+        identity = []
+        check = {"path": path, "identity": identity, "read": False}
+        self.state["worker_checks"].append(check)
+
+        def getpwnam(name):
+            assert name == "pkg5srv"
+            return types.SimpleNamespace(pw_uid=4242, pw_gid=4243)
+
+        def lstat(filename):
+            assert identity == [("groups", []), ("gid", 4243), ("uid", 4242)]
+            return os.lstat(self.safe_path(filename))
+
+        def worker_open(filename, mode):
+            assert identity == [("groups", []), ("gid", 4243), ("uid", 4242)]
+            assert filename == path and mode == "rb"
+            # World access is sufficient for this deliberately 0755/0644 stage.
+            # Walk REAL ancestors as well as the file, not just root's os.access.
+            parent = os.path.dirname(path)
+            while True:
+                assert os.stat(parent).st_mode & stat.S_IXOTH, parent
+                if parent == "/":
+                    break
+                parent = os.path.dirname(parent)
+            assert os.stat(path).st_mode & stat.S_IROTH
+            if self.state["fault"] == "worker":
+                raise OSError("stub pkg5srv access denied")
+            check["read"] = True
+            check["directory_mode"] = stat.S_IMODE(
+                os.stat(os.path.dirname(path)).st_mode
+            )
+            check["file_mode"] = stat.S_IMODE(os.stat(path).st_mode)
+            return open(path, mode)
+
+        def exit_probe(message):
+            raise OSError(message)
+
+        modules = {
+            "os": types.SimpleNamespace(
+                setgroups=lambda groups: identity.append(("groups", groups)),
+                setgid=lambda gid: identity.append(("gid", gid)),
+                setuid=lambda uid: identity.append(("uid", uid)),
+                lstat=lstat,
+            ),
+            "pwd": types.SimpleNamespace(getpwnam=getpwnam),
+            "stat": stat,
+            "sys": types.SimpleNamespace(argv=["-c", path], exit=exit_probe),
+        }
+
+        def import_probe(name, *args, **kwargs):
+            return modules[name]
+
+        probe_builtins = dict(vars(builtins))
+        probe_builtins.update(__import__=import_probe, open=worker_open)
+        exec(compile(script, "<production pkg5srv probe>", "exec"),
+             {"__builtins__": probe_builtins})
+        return self.result()
+
+    def stub_shell(self):
+        return self.stub_command()
+
+    def stub_command(self):
+        # Match command/shell check mode: read-only tasks explicitly override it.
+        if self.check:
+            return {"changed": False, "skipped": True}
+        argv = self.args.get("argv")
+        if argv is None:
+            argv = shlex.split(self.args.get("cmd", self.args.get("_raw_params")))
+        self.event["argv"] = argv
+        entry = {
+            "argv": argv, "task": self._task.get_name(),
+            "environment": self._task.environment,
+        }
+        self.state["commands"].append(entry)
+        fault = self.state["fault"]
+
+        if len(argv) == 4 and argv[1] == "-c":
+            return self.worker_probe(argv[2], argv[3])
+
+        if argv[:2] == ["pkg", "info"] or argv[0] == "pkginfo":
+            package = argv[-1]
+            installed = self.state["installed"][package]
+            is_ips = argv[0] == "pkg"
+            if fault == "ips_probe" and is_ips:
+                return self.result(1, stderr="stub IPS registration query error")
+            if fault == "svr4_probe" and not is_ips:
+                return self.result(1, stderr="stub SVR4 registration query error")
+            # pkginfo also succeeds for IPS compatibility registrations.
+            present = (installed["system"] == "ips" if is_ips
+                       else bool(installed["system"]))
+            if present:
+                label = "Version" if is_ips else "VERSION"
+                return self.result(stdout="%s: %s\n" % (label, installed["version"]))
+            return self.result(1, stderr=(
+                "pkg: info: no packages matching %s installed" % package
+                if is_ips else "ERROR: information for %s was not found" % package
+            ))
+
+        if argv[:2] == ["pkg", "list-linked"]:
+            if fault == "linked":
+                return self.result(1, stderr="stub linked discovery error")
+            return self.result(stdout=self.state["linked"])
+
+        if argv == ["pkg", "publisher", "-H", "-F", "tsv"]:
+            self.state["publisher_queries"] += 1
+            if (fault == "publisher"
+                    or (fault == "second_publisher"
+                        and self.state["publisher_queries"] == 2)):
+                return self.result(1, stderr="stub publisher query error")
+            if fault == "tsv":
+                return self.result(stdout="OneIdentity\ttrue\n")
+            if not self.state["publisher_exists"]:
+                return self.result()
+            syspub = "true" if fault == "system" else "false"
+            return self.result(stdout="\n".join(
+                "OneIdentity\ttrue\t%s\t%s\torigin\tonline\t%s\t%s"
+                % (syspub, enabled, uri, proxy)
+                for enabled, uri, proxy in self.state["origins"]
+            ))
+
+        if argv == ["pkg", "publisher", "OneIdentity"]:
+            if fault == "details":
+                return self.result(3, stdout="Publisher: OneIdentity\n")
+            enabled = "Yes" if self.state["publisher_enabled"] else "No"
+            credential = "/var/pkg/ssl/test-key" if fault == "ssl" else "None"
+            output = ("Publisher: OneIdentity\n%s: %s\n"
+                      "SSL Key: %s\nSSL Cert: None\n") % (
+                          self.state["enabled_label"], enabled, credential,
+                      )
+            rc = 1 if fault == "detail_query" else self.state["detail_rc"]
+            return self.result(rc, stdout=output)
+
+        if "pkgrm" in argv or argv[:2] == ["pkg", "uninstall"]:
+            package = argv[-1]
+            installed = self.state["installed"][package]
+            assert installed["system"], "Double removal of an absent package"
+            expected = "svr4" if "pkgrm" in argv else "ips"
+            assert installed["system"] == expected, "Removed with the wrong tool"
+            installed.update(system="", version="")
+            return self.result(self.state["svr4_rc"] if expected == "svr4" else 0)
+
+        if "pkgadd" in argv or argv[:2] == ["pkg", "install"]:
+            if fault == "install":
+                return self.result(1, stderr="stub package install error")
+            package = argv[-1].split("/")[-1].split("@")[0]
+            self.state["installed"][package].update(
+                system="svr4" if "pkgadd" in argv else "ips",
+                version=self.state["target_version"],
+            )
+            return self.result(self.state["svr4_rc"] if "pkgadd" in argv else 0)
+
+        if argv[:2] == ["pkg", "set-publisher"]:
+            if "-g" in argv:
+                origin = argv[argv.index("-g") + 1]
+                if os.path.dirname(origin) in self.state["stages"]:
+                    self.state["temp_origin"] = origin
+                    if fault == "set_publisher":
+                        return self.result(1, stderr="stub partial publisher error")
+                elif fault == "restore":
+                    return self.result(1, stderr="stub original origin restore error")
+            elif "-G" in argv:
+                if fault == "detach":
+                    return self.result(1, stderr="stub temporary origin cleanup error")
+                self.state["temp_origin"] = None
+            if "--enable" in argv:
+                self.state["publisher_enabled"] = True
+            if "--disable" in argv:
+                self.state["publisher_enabled"] = False
+            return self.result()
+
+        if argv[:2] == ["pkg", "unset-publisher"]:
+            if fault == "unset":
+                return self.result(1, stderr="stub temporary publisher cleanup error")
+            self.state["temp_origin"] = None
+            return self.result()
+
+        raise AssertionError("Unrecognised command; never execute it: %r" % argv)

--- a/tests/unit/roles/client_sw/test_solaris_install.py
+++ b/tests/unit/roles/client_sw/test_solaris_install.py
@@ -23,6 +23,8 @@ FIXTURES = Path(__file__).resolve().parent / "fixtures"
 SOLARIS = ROOT / "roles/client_sw/tasks/os/solaris"
 PLAYBOOK = os.environ.get("SOLARIS_TEST_ANSIBLE_PLAYBOOK", "ansible-playbook")
 TARGET_VERSION = "7.1.0.1000"
+NEWER_CATALOG_VERSION = "9.0.0.1000"
+LINKED_CHILD = "zone:sample child /zones/sample/root\n"
 
 
 def walk_tasks(tasks):
@@ -42,10 +44,10 @@ class SolarisInstallTests(unittest.TestCase):
         self.root.chmod(0o755)
 
     def run_case(self, route="equal", registered="svr4", fault="", check=False,
-                 linked="zone:sample child /zones/sample/root\n", major="11",
+                 linked=LINKED_CHILD, major="11",
                  state="present", publisher_exists=True, publisher_enabled=True,
                  enabled_label="Publisher enabled", detail_rc=0, svr4_rc=0,
-                 packages=("vasclnt",)):
+                 packages=("vasclnt",), newer_catalog_version=""):
         sandbox = Path(tempfile.mkdtemp(dir=str(self.root)))
         sandbox.chmod(0o755)
         for name in ("stage-root", "controller", "actions", "bin", "local-tmp"):
@@ -94,6 +96,7 @@ class SolarisInstallTests(unittest.TestCase):
                 } for package in packages
             },
             "target_version": TARGET_VERSION,
+            "newer_catalog_version": newer_catalog_version,
             "linked": linked, "publisher_exists": publisher_exists,
             "publisher_enabled": publisher_enabled,
             "enabled_label": enabled_label, "detail_rc": detail_rc,
@@ -106,6 +109,9 @@ class SolarisInstallTests(unittest.TestCase):
             "publisher_queries": 0, "temp_origin": None,
             "events": [], "commands": [], "stages": [], "cleaned": [],
             "worker_checks": [],
+        }
+        initial_installed = {
+            package: dict(installed) for package, installed in data["installed"].items()
         }
         state_path = sandbox / "state.json"
         state_path.write_text(json.dumps(data))
@@ -149,6 +155,7 @@ class SolarisInstallTests(unittest.TestCase):
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=90,
         )
         data = json.loads(state_path.read_text())
+        data["initial_installed"] = initial_installed
         data["sandbox"] = sandbox
         data["old_archive"] = old_archive
         data["source"] = source
@@ -162,6 +169,13 @@ class SolarisInstallTests(unittest.TestCase):
             event for event in data["commands"]
             if "pkgrm" in event["argv"]
             or event["argv"][:2] == ["pkg", "uninstall"]
+        ]
+
+    @staticmethod
+    def ips_installs(data):
+        return [
+            event for event in data["commands"]
+            if event["argv"][:2] == ["pkg", "install"]
         ]
 
     @staticmethod
@@ -213,11 +227,17 @@ class SolarisInstallTests(unittest.TestCase):
             with self.subTest(registered=registered, route=route):
                 completed, data = self.run_case(registered=registered, route=route)
                 self.assert_success(completed)
-                self.assertEqual(len(self.removals(data)), 1)
-                self.assertEqual(data["installed"]["vasclnt"]["system"], "ips")
+                self.assertEqual(len(self.removals(data)),
+                                 1 if registered == "svr4" else 0)
+                self.assertTrue(all("pkgrm" in event["argv"]
+                                    for event in self.removals(data)))
+                self.assertEqual(data["installed"]["vasclnt"], {
+                    "system": "ips", "version": TARGET_VERSION,
+                })
                 self.assertEqual(data["stages"], data["cleaned"])
                 self.assertEqual(len(data["stages"]), 1)
                 self.assertFalse(Path(data["stages"][0]).exists())
+                self.assertEqual(len(data["worker_checks"]), 1)
                 worker = data["worker_checks"][0]
                 self.assertTrue(worker["read"])
                 self.assertEqual(worker["directory_mode"], 0o755)
@@ -228,8 +248,12 @@ class SolarisInstallTests(unittest.TestCase):
                 commands = [event["argv"] for event in data["commands"]]
                 worker_index = next(i for i, cmd in enumerate(commands)
                                     if len(cmd) == 4 and cmd[1] == "-c")
-                removal_index = commands.index(self.removals(data)[0]["argv"])
-                self.assertLess(worker_index, removal_index)
+                # IPS downgrade has no removal. Worker access must still
+                # precede EVERY package/publisher mutation, including install.
+                for mutation in (self.removals(data) + self.publisher_mutations(data)
+                                 + self.ips_installs(data)):
+                    self.assertLess(worker_index, commands.index(mutation["argv"]),
+                                    mutation)
                 self.assertIn([
                     "pkg", "install", "--accept",
                     "pkg://OneIdentity/vasclnt@" + TARGET_VERSION,
@@ -260,14 +284,86 @@ class SolarisInstallTests(unittest.TestCase):
                 )
                 self.assertGreater(cleanup, last_publisher)
 
-    def test_downgrade_refresh_prevents_a_second_pkgrm(self):
+    def test_downgrade_live_probes_precede_single_pkgrm(self):
         completed, data = self.run_case(route="downgrade")
         self.assert_success(completed)
-        commands = [event["argv"] for event in data["commands"]]
-        removal = commands.index(self.removals(data)[0]["argv"])
-        self.assertIn(["pkg", "info", "vasclnt"], commands[removal + 1:])
-        self.assertIn(["pkginfo", "vasclnt"], commands[removal + 1:])
         self.assertEqual(len(self.removals(data)), 1)
+        self.assertIn("pkgrm", self.removals(data)[0]["argv"])
+        commands = [event["argv"] for event in data["commands"]]
+        worker = next(i for i, cmd in enumerate(commands)
+                      if len(cmd) == 4 and cmd[1] == "-c")
+        removal = commands.index(self.removals(data)[0]["argv"])
+        for probe in (["pkg", "info", "vasclnt"], ["pkginfo", "vasclnt"]):
+            # Ignore the cached version probes before preflight: the helper's
+            # live probes must authorise migration, not follow remove.yml.
+            probe_index = commands.index(probe, worker + 1)
+            self.assertLess(worker, probe_index)
+            self.assertLess(probe_index, removal)
+        self.assertTrue(self.removals(data)[0]["task"].endswith(
+            "migrate legacy SVR4 vasclnt to IPS"
+        ))
+        self.assertEqual(len(self.ips_installs(data)), 1)
+        self.assertLess(removal, commands.index(self.ips_installs(data)[0]["argv"]))
+        self.assertEqual(data["installed"]["vasclnt"], {
+            "system": "ips", "version": TARGET_VERSION,
+        })
+
+    def test_ips_downgrade_installs_requested_version_without_uninstall(self):
+        for linked in ("", LINKED_CHILD):
+            with self.subTest(linked=linked):
+                completed, data = self.run_case(
+                    route="downgrade", registered="ips", linked=linked,
+                )
+                self.assert_success(completed)
+                self.assertEqual(self.removals(data), [])
+                self.assertEqual(len(self.ips_installs(data)), 1)
+                self.assertEqual(self.ips_installs(data)[0]["argv"][-1],
+                                 "pkg://OneIdentity/vasclnt@" + TARGET_VERSION)
+                self.assertEqual(data["installed"]["vasclnt"], {
+                    "system": "ips", "version": TARGET_VERSION,
+                })
+                self.assertIsNone(data["temp_origin"])
+                self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_failed_ips_transitions_preserve_original_version_and_system(self):
+        for route in ("upgrade", "downgrade"):
+            for linked in ("", LINKED_CHILD):
+                with self.subTest(route=route, linked=linked):
+                    completed, data = self.run_case(
+                        route=route, registered="ips", linked=linked,
+                        fault="install", publisher_enabled=False,
+                    )
+                    self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                    self.assertIn("stub package install error", completed.stdout)
+                    self.assertEqual(data["installed"], data["initial_installed"])
+                    self.assertEqual(self.removals(data), [])
+                    self.assertEqual(len(self.ips_installs(data)), 1)
+                    self.assertFalse(data["publisher_enabled"])
+                    self.assertIsNone(data["temp_origin"])
+                    self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_direct_installs_pin_media_version_despite_newer_catalog(self):
+        for route in ("install", "upgrade", "downgrade"):
+            with self.subTest(route=route):
+                completed, data = self.run_case(
+                    route=route, registered="ips", linked="",
+                    newer_catalog_version=NEWER_CATALOG_VERSION,
+                )
+                self.assert_success(completed)
+                # The stub selects the newer catalog release for an
+                # unversioned operand, rather than always forcing the media.
+                self.assertEqual(data["installed"]["vasclnt"], {
+                    "system": "ips", "version": TARGET_VERSION,
+                })
+                self.assertEqual(
+                    [event["argv"] for event in self.ips_installs(data)], [[
+                        "pkg", "install", "--accept", "-g",
+                        str(data["old_archive"]),
+                        "pkg://OneIdentity/vasclnt@" + TARGET_VERSION,
+                    ]],
+                )
+                self.assertEqual(self.removals(data), [])
+                self.assertEqual(self.publisher_mutations(data), [])
 
     def test_restore_enabled_state_origins_and_proxies_with_both_detail_labels(self):
         for label in ("Enabled", "Publisher enabled"):
@@ -360,11 +456,11 @@ class SolarisInstallTests(unittest.TestCase):
                 self.assertEqual(data["publisher_queries"], 0)
                 self.assertEqual(data["stages"], [])
                 self.assertEqual(len(self.removals(data)), 1)
-                installs = [event["argv"] for event in data["commands"]
-                            if event["argv"][:2] == ["pkg", "install"]]
+                installs = [event["argv"] for event in self.ips_installs(data)]
                 self.assertEqual(installs, [[
                     "pkg", "install", "--accept", "-g",
-                    str(data["old_archive"]), "vasclnt",
+                    str(data["old_archive"]),
+                    "pkg://OneIdentity/vasclnt@" + TARGET_VERSION,
                 ]])
 
     def test_ips_compatibility_registration_does_not_trigger_pkgrm(self):
@@ -389,17 +485,26 @@ class SolarisInstallTests(unittest.TestCase):
         self.assertEqual(self.removals(data), [])
         self.assertEqual(data["publisher_queries"], 0)
 
-    def test_solaris10_upgrade_keeps_interactive_completed_svr4_outcomes(self):
-        for rc in (0, 2, 10, 20):
-            with self.subTest(rc=rc):
-                completed, data = self.run_case(major="10", route="upgrade", svr4_rc=rc)
-                self.assert_success(completed)
-                self.assertEqual(len(self.removals(data)), 1)
-                commands = [event["argv"] for event in data["commands"]]
-                self.assertTrue(any("pkgadd" in cmd for cmd in commands))
-                self.assertFalse(any("-n" in cmd for cmd in commands))
-                self.assertFalse(any(cmd[0] == "pkg" for cmd in commands))
-                self.assertEqual(data["stages"], [])
+    def test_solaris10_transitions_keep_interactive_completed_svr4_outcomes(self):
+        for route in ("upgrade", "downgrade"):
+            for rc in (0, 2, 10, 20):
+                with self.subTest(route=route, rc=rc):
+                    completed, data = self.run_case(
+                        major="10", route=route, svr4_rc=rc,
+                    )
+                    self.assert_success(completed)
+                    self.assertEqual(len(self.removals(data)), 1)
+                    commands = [event["argv"] for event in data["commands"]]
+                    installs = [cmd for cmd in commands if "pkgadd" in cmd]
+                    self.assertEqual(len(installs), 1)
+                    self.assertLess(commands.index(self.removals(data)[0]["argv"]),
+                                    commands.index(installs[0]))
+                    self.assertFalse(any("-n" in cmd for cmd in commands))
+                    self.assertFalse(any(cmd[0] == "pkg" for cmd in commands))
+                    self.assertEqual(data["installed"]["vasclnt"], {
+                        "system": "svr4", "version": TARGET_VERSION,
+                    })
+                    self.assertEqual(data["stages"], [])
 
     def test_second_package_cannot_reuse_first_packages_cleanup_markers(self):
         completed, data = self.run_case(
@@ -421,6 +526,21 @@ class SolarisInstallTests(unittest.TestCase):
 
 
 class SolarisTaskContractTests(unittest.TestCase):
+    def test_both_ips_install_paths_keep_rc_zero_and_four_handling(self):
+        installs = [
+            task for task in walk_tasks(
+                yaml.safe_load((SOLARIS / "install_package.yml").read_text())
+            )
+            if task.get("command", {}).get("cmd", "").startswith("pkg install ")
+        ]
+        self.assertEqual(len(installs), 2)
+        for task in installs:
+            with self.subTest(task=task["name"]):
+                self.assertEqual(task["changed_when"], "pkg_install.rc == 0")
+                self.assertEqual(task["failed_when"], [
+                    "pkg_install.rc != 0", "pkg_install.rc != 4",
+                ])
+
     def test_all_four_registration_probes_keep_check_mode_and_locale_guards(self):
         probes = []
         for filename in ("version.yml", "install_package.yml"):

--- a/tests/unit/roles/client_sw/test_solaris_install.py
+++ b/tests/unit/roles/client_sw/test_solaris_install.py
@@ -1,0 +1,450 @@
+"""Regression tests of actual Solaris task ordering with safe action stubs.
+
+Run with unittest or pytest. No Solaris commands, privilege changes, SSH or
+package installation occur. Set SOLARIS_TEST_ANSIBLE_PLAYBOOK to exercise another
+already-installed controller, including Ansible 2.9/2.10.
+"""
+
+import json
+import os
+from pathlib import Path
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+SOLARIS = ROOT / "roles/client_sw/tasks/os/solaris"
+PLAYBOOK = os.environ.get("SOLARIS_TEST_ANSIBLE_PLAYBOOK", "ansible-playbook")
+TARGET_VERSION = "7.1.0.1000"
+
+
+def walk_tasks(tasks):
+    for task in tasks:
+        yield task
+        for section in ("block", "rescue", "always"):
+            for nested in walk_tasks(task.get(section, [])):
+                yield nested
+
+
+@unittest.skipUnless(shutil.which(PLAYBOOK), "ansible-playbook is required")
+class SolarisInstallTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(prefix="solaris-role-test-")
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.root.chmod(0o755)
+
+    def run_case(self, route="equal", registered="svr4", fault="", check=False,
+                 linked="zone:sample child /zones/sample/root\n", major="11",
+                 state="present", publisher_exists=True, publisher_enabled=True,
+                 enabled_label="Publisher enabled", detail_rc=0, svr4_rc=0,
+                 packages=("vasclnt",)):
+        sandbox = Path(tempfile.mkdtemp(dir=str(self.root)))
+        sandbox.chmod(0o755)
+        for name in ("stage-root", "controller", "actions", "bin", "local-tmp"):
+            (sandbox / name).mkdir(mode=0o755)
+        private = sandbox / "private"
+        private.mkdir(mode=0o700)
+        old_directory = private / "ansible-as-client_sw"
+        old_directory.mkdir(mode=0o700)
+        old_archive = old_directory / "sas.p5p"
+        old_archive.write_bytes(b"pre-existing caller media\n")
+        old_archive.chmod(0o600)
+        source = sandbox / "controller/sas.p5p"
+        source.write_bytes(b"test archive content\n")
+        source.chmod(0o600)
+        if fault == "media":
+            source.unlink()
+        unrelated = sandbox / "stage-root/unrelated"
+        unrelated.mkdir()
+        (unrelated / "keep").write_text("not owned by the install operation\n")
+
+        for action in ("command", "shell", "copy", "file", "tempfile"):
+            shutil.copyfile(
+                str(FIXTURES / "solaris_actions.py"),
+                str(sandbox / "actions" / (action + ".py")),
+            )
+        # Defence in depth: even a broken action-plugin override cannot invoke
+        # an actual package command from the local machine's PATH.
+        for command in ("pkg", "pkginfo", "pkgrm", "pkgadd"):
+            guard = sandbox / "bin" / command
+            guard.write_text("#!/bin/sh\nexit 99\n")
+            guard.chmod(0o755)
+        config = sandbox / "ansible.cfg"
+        config.write_text(
+            "[defaults]\nretry_files_enabled = False\nstdout_callback = default\n"
+        )
+        versions = {
+            "equal": TARGET_VERSION, "downgrade": "8.0.0.1000",
+            "upgrade": "6.0.0.1000", "install": "",
+        }
+        data = {
+            "fault": fault,
+            "installed": {
+                package: {
+                    "system": registered if route != "install" else "",
+                    "version": versions[route],
+                } for package in packages
+            },
+            "target_version": TARGET_VERSION,
+            "linked": linked, "publisher_exists": publisher_exists,
+            "publisher_enabled": publisher_enabled,
+            "enabled_label": enabled_label, "detail_rc": detail_rc,
+            "svr4_rc": svr4_rc,
+            "origins": [
+                ["true", "https://packages.example.invalid/primary/", "-"],
+                ["false", "https://packages.example.invalid/secondary/",
+                 "http://proxy.example.invalid:8080"],
+            ],
+            "publisher_queries": 0, "temp_origin": None,
+            "events": [], "commands": [], "stages": [], "cleaned": [],
+            "worker_checks": [],
+        }
+        state_path = sandbox / "state.json"
+        state_path.write_text(json.dumps(data))
+        variables = {
+            "solaris_test_root": str(sandbox),
+            "solaris_test_major": major,
+            "solaris_test_python": sys.executable,
+            "solaris_test_packages": [
+                {"key": package, "value": state} for package in packages
+            ],
+            "client_sw_pkgs": {
+                "packages": {
+                    package: {
+                        "path": str(source), "file": "sas.p5p",
+                        "vers": TARGET_VERSION,
+                    } for package in packages
+                },
+            },
+        }
+        environment = dict(os.environ)
+        environment.update({
+            "ANSIBLE_CONFIG": str(config),
+            "ANSIBLE_ACTION_PLUGINS": str(sandbox / "actions"),
+            "ANSIBLE_ROLES_PATH": str(ROOT / "roles"),
+            "ANSIBLE_LOCAL_TEMP": str(sandbox / "local-tmp"),
+            "ANSIBLE_LOG_PATH": os.devnull,
+            "ANSIBLE_NOCOLOR": "1",
+            # This existing collection uses string truthiness in routing;
+            # modern 2.19+ controllers otherwise reject its old conditionals.
+            "ANSIBLE_ALLOW_BROKEN_CONDITIONALS": "True",
+            "PATH": str(sandbox / "bin") + os.pathsep + os.environ["PATH"],
+        })
+        command = [
+            PLAYBOOK, "-i", "localhost,", "-c", "local",
+            str(FIXTURES / "solaris.yml"), "-e", json.dumps(variables),
+        ]
+        if check:
+            command.append("--check")
+        completed = subprocess.run(
+            command, cwd=str(ROOT), env=environment, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=90,
+        )
+        data = json.loads(state_path.read_text())
+        data["sandbox"] = sandbox
+        data["old_archive"] = old_archive
+        data["source"] = source
+        self.assertTrue(data["commands"], completed.stdout)
+        self.assertTrue((unrelated / "keep").is_file(), completed.stdout)
+        return completed, data
+
+    @staticmethod
+    def removals(data):
+        return [
+            event for event in data["commands"]
+            if "pkgrm" in event["argv"]
+            or event["argv"][:2] == ["pkg", "uninstall"]
+        ]
+
+    @staticmethod
+    def publisher_mutations(data):
+        return [
+            event for event in data["commands"]
+            if event["argv"][:2] in (
+                ["pkg", "set-publisher"], ["pkg", "unset-publisher"],
+            )
+        ]
+
+    def assert_success(self, completed):
+        self.assertEqual(completed.returncode, 0, completed.stdout)
+
+    def assert_rejected(self, completed, data, reason):
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn(reason, completed.stdout)
+        self.assertEqual(self.removals(data), [], completed.stdout)
+        self.assertEqual(self.publisher_mutations(data), [], completed.stdout)
+        self.assertEqual(data["stages"], data["cleaned"], completed.stdout)
+
+    def test_preflight_rejections_preserve_installed_packages_on_all_routes(self):
+        faults = {
+            "ssl": "SSL client credentials",
+            "system": "SYSPUB=true",
+            "linked": "stub linked discovery error",
+            "publisher": "stub publisher query error",
+            "detail_query": "complete OneIdentity publisher configuration",
+            "details": "complete OneIdentity publisher configuration",
+            "tsv": "complete OneIdentity publisher TSV configuration",
+            "tempfile": "stub stage allocation error",
+            "copy": "stub required archive copy error",
+            "media": "stub required media missing",
+            "worker": "stub pkg5srv access denied",
+        }
+        for registered, route in (
+                ("svr4", "equal"), ("svr4", "downgrade"), ("ips", "downgrade")):
+            for fault, reason in faults.items():
+                with self.subTest(registered=registered, route=route, fault=fault):
+                    completed, data = self.run_case(
+                        registered=registered, route=route, fault=fault,
+                    )
+                    self.assert_rejected(completed, data, reason)
+                    self.assertEqual(data["installed"]["vasclnt"]["system"], registered)
+
+    def test_readable_unique_stage_precedes_migration_and_both_downgrades(self):
+        for registered, route in (
+                ("svr4", "equal"), ("svr4", "downgrade"), ("ips", "downgrade")):
+            with self.subTest(registered=registered, route=route):
+                completed, data = self.run_case(registered=registered, route=route)
+                self.assert_success(completed)
+                self.assertEqual(len(self.removals(data)), 1)
+                self.assertEqual(data["installed"]["vasclnt"]["system"], "ips")
+                self.assertEqual(data["stages"], data["cleaned"])
+                self.assertEqual(len(data["stages"]), 1)
+                self.assertFalse(Path(data["stages"][0]).exists())
+                worker = data["worker_checks"][0]
+                self.assertTrue(worker["read"])
+                self.assertEqual(worker["directory_mode"], 0o755)
+                self.assertEqual(worker["file_mode"], 0o644)
+                self.assertEqual(worker["identity"], [
+                    ["groups", []], ["gid", 4243], ["uid", 4242],
+                ])
+                commands = [event["argv"] for event in data["commands"]]
+                worker_index = next(i for i, cmd in enumerate(commands)
+                                    if len(cmd) == 4 and cmd[1] == "-c")
+                removal_index = commands.index(self.removals(data)[0]["argv"])
+                self.assertLess(worker_index, removal_index)
+                self.assertIn([
+                    "pkg", "install", "--accept",
+                    "pkg://OneIdentity/vasclnt@" + TARGET_VERSION,
+                ], commands)
+                self.assertEqual(
+                    stat.S_IMODE(data["sandbox"].joinpath("private").stat().st_mode),
+                    0o700,
+                )
+                self.assertEqual(stat.S_IMODE(data["old_archive"].stat().st_mode), 0o600)
+                self.assertEqual(data["old_archive"].read_bytes(),
+                                 b"pre-existing caller media\n")
+                self.assertEqual(stat.S_IMODE(data["source"].stat().st_mode), 0o600)
+                self.assertTrue(all(
+                    event["args"].get("owner") == "root"
+                    for event in data["events"]
+                    if event["action"] in ("copy", "file")
+                    and event["args"].get("state") != "absent"
+                    and event["args"].get("dest", event["args"].get("path", ""))
+                    .startswith(data["stages"][0])
+                ))
+                cleanup = next(i for i, event in enumerate(data["events"])
+                               if event["action"] == "file"
+                               and event["args"].get("state") == "absent")
+                last_publisher = max(
+                    i for i, event in enumerate(data["events"])
+                    if event["action"] == "command"
+                    and event.get("argv", [])[:2] == ["pkg", "set-publisher"]
+                )
+                self.assertGreater(cleanup, last_publisher)
+
+    def test_downgrade_refresh_prevents_a_second_pkgrm(self):
+        completed, data = self.run_case(route="downgrade")
+        self.assert_success(completed)
+        commands = [event["argv"] for event in data["commands"]]
+        removal = commands.index(self.removals(data)[0]["argv"])
+        self.assertIn(["pkg", "info", "vasclnt"], commands[removal + 1:])
+        self.assertIn(["pkginfo", "vasclnt"], commands[removal + 1:])
+        self.assertEqual(len(self.removals(data)), 1)
+
+    def test_restore_enabled_state_origins_and_proxies_with_both_detail_labels(self):
+        for label in ("Enabled", "Publisher enabled"):
+            with self.subTest(label=label):
+                completed, data = self.run_case(
+                    publisher_enabled=False, enabled_label=label, detail_rc=3,
+                )
+                self.assert_success(completed)
+                commands = [event["argv"] for event in self.publisher_mutations(data)]
+                self.assertIn(["pkg", "set-publisher", "--enable", "OneIdentity"], commands)
+                self.assertIn(["pkg", "set-publisher", "--disable", "OneIdentity"], commands)
+                self.assertIn([
+                    "pkg", "set-publisher", "--no-refresh", "--disable",
+                    "-g", "https://packages.example.invalid/secondary/",
+                    "--proxy", "http://proxy.example.invalid:8080", "OneIdentity",
+                ], commands)
+                self.assertFalse(data["publisher_enabled"])
+                self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_new_publisher_is_unset_before_stage_cleanup(self):
+        completed, data = self.run_case(publisher_exists=False)
+        self.assert_success(completed)
+        self.assertEqual(
+            self.publisher_mutations(data)[-1]["argv"],
+            ["pkg", "unset-publisher", "OneIdentity"],
+        )
+        self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_failed_install_still_restores_publisher_and_cleans_stage(self):
+        completed, data = self.run_case(fault="install", publisher_enabled=False)
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("stub package install error", completed.stdout)
+        self.assertEqual(len(self.removals(data)), 1)
+        self.assertFalse(data["publisher_enabled"])
+        self.assertIsNone(data["temp_origin"])
+        self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_stage_is_retained_only_while_publisher_may_still_use_it(self):
+        for fault, exists in (("detach", True), ("unset", False), ("set_publisher", True)):
+            with self.subTest(fault=fault):
+                completed, data = self.run_case(fault=fault, publisher_exists=exists)
+                self.assertNotEqual(completed.returncode, 0, completed.stdout)
+                self.assertIn("Retaining", completed.stdout)
+                self.assertEqual(data["cleaned"], [])
+                self.assertTrue(Path(data["stages"][0], "archive.p5p").is_file())
+                self.assertIsNotNone(data["temp_origin"])
+
+    def test_failed_old_origin_restoration_does_not_leak_detached_stage(self):
+        completed, data = self.run_case(fault="restore")
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("could not restore OneIdentity origin", completed.stdout)
+        self.assertIsNone(data["temp_origin"])
+        self.assertEqual(data["stages"], data["cleaned"])
+        restored = [event for event in self.publisher_mutations(data)
+                    if any("packages.example.invalid" in arg for arg in event["argv"])]
+        self.assertEqual(len(restored), 2)  # Both restorations attempted despite errors.
+
+    def test_check_mode_probes_without_mutations_or_missing_tempfile_attributes(self):
+        for route in ("equal", "downgrade"):
+            with self.subTest(route=route):
+                completed, data = self.run_case(route=route, check=True)
+                self.assert_success(completed)
+                self.assertEqual(self.removals(data), [])
+                self.assertEqual(self.publisher_mutations(data), [])
+                self.assertEqual(data["stages"], [])
+                self.assertEqual(data["worker_checks"], [])
+                commands = [event["argv"] for event in data["commands"]]
+                for probe in (["pkg", "info", "vasclnt"], ["pkginfo", "-l", "vasclnt"],
+                              ["pkginfo", "vasclnt"], ["pkg", "list-linked", "-H"]):
+                    self.assertIn(probe, commands)
+                self.assertEqual(commands.count(["pkg", "info", "vasclnt"]), 2)
+                self.assertFalse(any(cmd[:2] == ["pkg", "install"] for cmd in commands))
+                self.assertEqual(data["old_archive"].read_bytes(),
+                                 b"pre-existing caller media\n")
+
+    def test_check_mode_rejects_unsupported_publishers_and_missing_media(self):
+        for fault, reason in (("ssl", "SSL client credentials"),
+                              ("system", "SYSPUB=true"),
+                              ("media", "stub required media missing")):
+            with self.subTest(fault=fault):
+                completed, data = self.run_case(fault=fault, check=True, route="downgrade")
+                self.assert_rejected(completed, data, reason)
+
+    def test_parent_self_and_unlinked_images_keep_direct_archive_install(self):
+        for linked in ("", "zone:child parent /zones/parent/root\n"
+                           "self self /zones/child/root\n"):
+            with self.subTest(linked=linked):
+                completed, data = self.run_case(linked=linked, fault="ssl")
+                self.assert_success(completed)
+                self.assertEqual(data["publisher_queries"], 0)
+                self.assertEqual(data["stages"], [])
+                self.assertEqual(len(self.removals(data)), 1)
+                installs = [event["argv"] for event in data["commands"]
+                            if event["argv"][:2] == ["pkg", "install"]]
+                self.assertEqual(installs, [[
+                    "pkg", "install", "--accept", "-g",
+                    str(data["old_archive"]), "vasclnt",
+                ]])
+
+    def test_ips_compatibility_registration_does_not_trigger_pkgrm(self):
+        completed, data = self.run_case(registered="ips", route="upgrade", linked="")
+        self.assert_success(completed)
+        self.assertEqual(self.removals(data), [])
+
+    def test_absent_only_and_unchanged_ips_do_not_preflight_unused_media(self):
+        for registered in ("svr4", "ips"):
+            with self.subTest(registered=registered):
+                completed, data = self.run_case(
+                    state="absent", registered=registered, fault="media",
+                )
+                self.assert_success(completed)
+                self.assertEqual(len(self.removals(data)), 1)
+                self.assertEqual(data["publisher_queries"], 0)
+                self.assertEqual(data["stages"], [])
+                self.assertFalse(any(event["argv"][:2] == ["pkg", "list-linked"]
+                                     for event in data["commands"]))
+        completed, data = self.run_case(registered="ips", fault="media")
+        self.assert_success(completed)
+        self.assertEqual(self.removals(data), [])
+        self.assertEqual(data["publisher_queries"], 0)
+
+    def test_solaris10_upgrade_keeps_interactive_completed_svr4_outcomes(self):
+        for rc in (0, 2, 10, 20):
+            with self.subTest(rc=rc):
+                completed, data = self.run_case(major="10", route="upgrade", svr4_rc=rc)
+                self.assert_success(completed)
+                self.assertEqual(len(self.removals(data)), 1)
+                commands = [event["argv"] for event in data["commands"]]
+                self.assertTrue(any("pkgadd" in cmd for cmd in commands))
+                self.assertFalse(any("-n" in cmd for cmd in commands))
+                self.assertFalse(any(cmd[0] == "pkg" for cmd in commands))
+                self.assertEqual(data["stages"], [])
+
+    def test_second_package_cannot_reuse_first_packages_cleanup_markers(self):
+        completed, data = self.run_case(
+            packages=("vasclnt", "vasgp"), fault="second_publisher",
+        )
+        self.assertNotEqual(completed.returncode, 0, completed.stdout)
+        self.assertIn("stub publisher query error", completed.stdout)
+        self.assertEqual([event["argv"][-1] for event in self.removals(data)], ["vasclnt"])
+        self.assertEqual(data["installed"]["vasgp"]["system"], "svr4")
+        self.assertEqual(len(data["stages"]), 1)
+        self.assertEqual(data["stages"], data["cleaned"])
+
+    def test_registration_query_errors_fail_closed(self):
+        for fault, reason in (("ips_probe", "stub IPS registration query error"),
+                              ("svr4_probe", "stub SVR4 registration query error")):
+            with self.subTest(fault=fault):
+                completed, data = self.run_case(fault=fault)
+                self.assert_rejected(completed, data, reason)
+
+
+class SolarisTaskContractTests(unittest.TestCase):
+    def test_all_four_registration_probes_keep_check_mode_and_locale_guards(self):
+        probes = []
+        for filename in ("version.yml", "install_package.yml"):
+            for task in walk_tasks(yaml.safe_load((SOLARIS / filename).read_text())):
+                cmd = task.get("command", {}).get("cmd", "")
+                if cmd.startswith(("pkg info ", "pkginfo ")):
+                    probes.append(task)
+        self.assertEqual(len(probes), 4)
+        for task in probes:
+            with self.subTest(task=task["name"]):
+                self.assertIs(task["check_mode"], False)
+                self.assertEqual(task["environment"], {"LC_ALL": "C"})
+                self.assertIs(task["changed_when"], False)
+                self.assertIs(task["failed_when"], False)
+
+    def test_new_nested_loops_do_not_override_outer_package_item(self):
+        for filename in ("install_preflight.yml", "install_package.yml"):
+            for task in walk_tasks(yaml.safe_load((SOLARIS / filename).read_text())):
+                if "loop" in task:
+                    self.assertNotEqual(
+                        task.get("loop_control", {}).get("loop_var", "item"), "item",
+                        task["name"],
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Branch the Solaris `client_sw` tasks on the OS major version so each release is
installed the native way:

- **Solaris 11+**: install from the IPS archive with
  `pkg install -g <sas-*.p5p>`; remove with `pkg uninstall`; read the installed
  version with `pkg info`.
- **Solaris 10**: install/remove the SVR4 package with an **interactive**
  `pkgadd`/`pkgrm` (answering `y`, no `-n`).

## Why

The Solaris tasks used the `svr4pkg` module, which runs `pkgadd -n`. On Solaris
the SVR4 package's postinstall registers its SMF service (and, on older
releases, its SysV `rc*.d` links) inside a block gated by the
`$SERVICES`/`$CLASSES` variables, and those are only set by the package's
**request script**. `pkgadd -n` does not run the request script, so the block
is skipped and the `vasd` SMF service (`svc:/quest/vas/vasd:default`) is never
registered — the daemon then cannot start after install. This affects
**Solaris 10 and 11**.

On Solaris 11 there is an additional factor: the native package is IPS
(`.p5p`), and the SMF services are registered by the IPS self-assembly service
that only runs on `pkg install`. Installing the legacy SVR4 package via
`pkgadd` bypasses it entirely.

Running `pkgadd`/`pkgrm` interactively (no `-n`) makes the request script run so
services register; on Solaris 11, `pkg install`/`pkg uninstall` register and
unregister them natively.

### Version detection

`version.yml` must query the matching package database (`pkg info` on 11,
`pkginfo` on 10). It now uses a **single** task that selects the command via a
conditional. Two tasks both registering `pkg_version` would let the skipped one
clobber the result — a skipped task still sets its registered variable, with no
`stdout` — which made the role treat installed packages as absent (breaking
remove/upgrade detection and idempotency).

## Testing

Ran the role end-to-end on Solaris 11 (x86 and SPARC):

- **install** → the `vasd` SMF service is registered;
- **re-run** → idempotent (no changes);
- **remove** → clean.

The Solaris 10 path (interactive `pkgadd`/`pkgrm`) was verified with the same
commands the tasks run.
